### PR TITLE
docs: add Chinese translations for README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,27 @@
 # Monorepo of Coze Orz
 [![codecov](https://codecov.io/gh/coze-dev/coze-js/graph/badge.svg?token=W5EBMZ0NUE)](https://codecov.io/gh/coze-dev/coze-js) ![ci](https://github.com/coze-dev/coze-js/actions/workflows/ci@main.yml/badge.svg)
 
+English | [简体中文](./README.zh-CN.md)
+
 ## 📦 Packages
 
 This monorepo contains the following packages:
 
 | Package | Description | Version |
 |---------|------------|---------|
-| [@coze/api](./packages/coze-js) | Coze API | [![npm](https://img.shields.io/npm/v/@coze/api.svg)](https://www.npmjs.com/package/@coze/api) |
-| [@coze/realtime-api](./packages/realtime-api) | Realtime API | [![npm](https://img.shields.io/npm/v/@coze/realtime-api.svg)](https://www.npmjs.com/package/@coze/realtime-api) |
+| [@coze/api](./packages/coze-js) | Coze API SDK | [![npm](https://img.shields.io/npm/v/@coze/api.svg)](https://www.npmjs.com/package/@coze/api) |
+| [@coze/realtime-api](./packages/realtime-api) | Realtime API SDK | [![npm](https://img.shields.io/npm/v/@coze/realtime-api.svg)](https://www.npmjs.com/package/@coze/realtime-api) |
+| [@coze/taro-api](./packages/coze-taro) | Taro Mini Program Coze API SDK | [![npm](https://img.shields.io/npm/v/@coze/taro-api.svg)](https://www.npmjs.com/package/@coze/taro-api) |
 
 
 ## 🎮 Examples
 
 Find usage examples for each package in the [examples](./examples) directory:
 
-- [coze-js-node](./examples/coze-js-node) - Node.js Demo for @coze/coze-js
-- [coze-js-web](./examples/coze-js-web) - React Web Demo for @coze/coze-js
+- [coze-js-node](./examples/coze-js-node) - Node.js Demo for @coze/api
+- [coze-js-web](./examples/coze-js-web) - React Web Demo for @coze/api
+- [coze-js-taro](./examples/coze-js-taro) - Taro4 Mini Program Demo for @coze/taro-api
+- [coze-js-taro3](./examples/coze-js-taro3) - Taro3 Mini Program Demo for @coze/taro-api
 - [realtime-console](./examples/realtime-console) - Full Console Demo for @coze/realtime-api
 - [realtime-call-up](./examples/realtime-call-up) - Sample Call Up Demo for @coze/realtime-api
 
@@ -85,6 +90,7 @@ npm run start
 
 ## 📖 Documentation
 
+- [Official Documentation](https://www.coze.com/docs/developer_guides/nodejs_overview)
 - [Contributing Guidelines](./CONTRIBUTING.md)
 - [How to publish](./docs/publish.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,97 @@
+# Coze Orz Monorepo
+[![codecov](https://codecov.io/gh/coze-dev/coze-js/graph/badge.svg?token=W5EBMZ0NUE)](https://codecov.io/gh/coze-dev/coze-js) ![ci](https://github.com/coze-dev/coze-js/actions/workflows/ci@main.yml/badge.svg)
+
+[English](./README.md) | 简体中文
+
+## 📦 包列表
+
+本 monorepo 包含以下包：
+
+| 包名 | 描述 | 版本 |
+|---------|------------|---------|
+| [@coze/api](./packages/coze-js) | Coze API SDK | [![npm](https://img.shields.io/npm/v/@coze/api.svg)](https://www.npmjs.com/package/@coze/api) |
+| [@coze/realtime-api](./packages/realtime-api) | 实时语音 SDK | [![npm](https://img.shields.io/npm/v/@coze/realtime-api.svg)](https://www.npmjs.com/package/@coze/realtime-api) |
+| [@coze/taro-api](./packages/coze-taro) | 支持 Taro 小程序的 Coze API SDK | [![npm](https://img.shields.io/npm/v/@coze/taro-api.svg)](https://www.npmjs.com/package/@coze/taro-api) |
+
+## 🎮 示例
+
+在 [examples](./examples) 目录中查找每个包的使用示例：
+
+- [coze-js-node](./examples/coze-js-node) - @coze/api 的 Node.js 使用示例
+- [coze-js-web](./examples/coze-js-web) - @coze/api 的 React Web 使用示例
+- [coze-js-taro](./examples/coze-js-taro) - @coze/taro-api Taro4 小程序示例
+- [coze-js-taro3](./examples/coze-js-taro3) - @coze/taro-api Taro3 小程序示例
+- [realtime-console](./examples/realtime-console) - @coze/realtime-api 完整版实时语音示例
+- [realtime-call-up](./examples/realtime-call-up) - @coze/realtime-api 简化版实时语音示例
+
+## 🚀 快速开始
+
+### 前置要求
+
+- Node.js 18+ (推荐 LTS/Hydrogen)
+- pnpm 9.12.0
+- Rush 5.140.0
+
+### 安装步骤
+
+1. **安装 Node.js 18+**
+
+```bash
+nvm install lts/hydrogen
+nvm alias default lts/hydrogen # 设置默认 node 版本
+nvm use lts/hydrogen
+```
+
+2. **克隆仓库**
+
+```bash
+git clone git@github.com:coze-dev/coze-js.git
+```
+
+3. **安装必需的全局依赖**
+
+```bash
+npm i -g pnpm@9.12.0 @microsoft/rush@5.140.0
+```
+
+4. **安装项目依赖**
+
+```bash
+rush update
+```
+
+5. **构建项目**
+
+```bash
+rush build
+```
+
+完成上述步骤后，你就可以开始在这个仓库中进行开发了。
+
+开始享受开发吧！
+
+## 🔨 开发
+
+此 monorepo 中的每个包都可以独立开发和发布。开始开发：
+
+1. 进入包目录：
+
+```bash
+cd packages/<package-name>
+```
+
+2. 启动开发：
+
+```bash
+npm run start
+```
+
+## 📖 文档
+
+- [官方文档](https://www.coze.cn/docs/developer_guides/nodejs_overview)
+- [贡献指南](./CONTRIBUTING.md)
+- [如何发布](./docs/publish.md)
+
+## 📄 许可证
+
+[MIT](./LICENSE)

--- a/common/changes/@coze/api/docs-readme_2025-01-05-03-17.json
+++ b/common/changes/@coze/api/docs-readme_2025-01-05-03-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/api",
+      "comment": "add Chinese translations for README files",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@coze/api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/common/changes/@coze/api/docs-readme_2025-01-05-04-19.json
+++ b/common/changes/@coze/api/docs-readme_2025-01-05-04-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/api",
+      "comment": "add Chinese translations for README files",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@coze/api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/common/changes/@coze/api/docs-readme_2025-01-05-04-37.json
+++ b/common/changes/@coze/api/docs-readme_2025-01-05-04-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/api",
+      "comment": "add Chinese translations for README files",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@coze/api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/common/changes/@coze/realtime-api/docs-readme_2025-01-05-03-17.json
+++ b/common/changes/@coze/realtime-api/docs-readme_2025-01-05-03-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/realtime-api",
+      "comment": "add Chinese translations for README files",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@coze/realtime-api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/common/changes/@coze/realtime-api/docs-readme_2025-01-05-04-19.json
+++ b/common/changes/@coze/realtime-api/docs-readme_2025-01-05-04-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/realtime-api",
+      "comment": "add Chinese translations for README files",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@coze/realtime-api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/common/changes/@coze/taro-api/docs-readme_2025-01-05-03-17.json
+++ b/common/changes/@coze/taro-api/docs-readme_2025-01-05-03-17.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/taro-api",
+      "comment": "add Chinese translations for README files",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@coze/taro-api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/common/changes/@coze/taro-api/docs-readme_2025-01-05-04-19.json
+++ b/common/changes/@coze/taro-api/docs-readme_2025-01-05-04-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/taro-api",
+      "comment": "add Chinese translations for README files",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@coze/taro-api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/examples/coze-js-node/README.md
+++ b/examples/coze-js-node/README.md
@@ -1,5 +1,7 @@
 # Coze Node.js Example
 
+English | [简体中文](./README.zh-CN.md)
+
 This guide will help you quickly set up and run the Coze Node.js example.
 
 ## Quick Start
@@ -8,10 +10,10 @@ This guide will help you quickly set up and run the Coze Node.js example.
 Please refer to the root [README.md](../../README.md) for dependency installation instructions.
 
 ### 2. Configure Environment
-1. Create your configuration file:
+1. Modify your configuration file:
 
 ```bash
-cp src/config/config.default.ts src/config/config.ts
+cd src/config/config.ts
 ```
 
 2. Update the following values in `config.ts`:
@@ -20,7 +22,7 @@ cp src/config/config.default.ts src/config/config.ts
 - `auth.pat.COZE_API_KEY`: Your Coze API key
 
 ### 3. Run the Example
-Choose one of the following commands based on your endpoint:
+Choose one of the following commands based on your Base URL:
 
 ```bash
 # For China region (api.coze.cn)

--- a/examples/coze-js-node/README.zh-CN.md
+++ b/examples/coze-js-node/README.zh-CN.md
@@ -1,0 +1,33 @@
+# Coze Node.js 示例
+
+[English](./README.md) | 简体中文
+
+本指南将帮助你快速设置和运行 Coze Node.js 示例。
+
+## 快速开始
+
+### 1. 安装依赖
+请参考根目录的 [README.md](../../README.md) 了解依赖安装说明。
+
+### 2. 配置环境
+1. 修改你的配置文件：
+
+```bash
+cd src/config/config.ts
+```
+
+2. 在 `config.ts` 中更新以下值：
+- `COZE_BOT_ID`：你的 Bot ID
+- `COZE_BASE_URL`：API 基础域名
+- `auth.pat.COZE_API_KEY`：你的 Coze API PAT
+
+### 3. 运行示例
+根据你的 Base URL 选择以下命令之一：
+
+```bash
+# 中国区域 (api.coze.cn)
+COZE_ENV=zh npx tsx ./src/chat.ts
+
+# 全球区域 (api.coze.com)
+npx tsx ./src/chat.ts
+```

--- a/examples/coze-js-web/README.md
+++ b/examples/coze-js-web/README.md
@@ -1,5 +1,7 @@
 # Coze JS Web Demo
 
+English | [简体中文](./README.zh-CN.md)
+
 A React-based web demo showcasing the capabilities of the Coze API, including chat and voice interactions.
 
 ## Features

--- a/examples/coze-js-web/README.zh-CN.md
+++ b/examples/coze-js-web/README.zh-CN.md
@@ -1,0 +1,26 @@
+# Coze JS Web 示例
+
+[English](./README.md) | 简体中文
+
+一个基于 React 的 Web 示例，展示了 Coze API 的功能，包括聊天和语音交互。
+
+## 功能特性
+
+- 支持流式响应的聊天界面
+- 语音交互支持
+- 文件上传功能
+- OAuth 和个人访问令牌认证
+
+## 快速开始
+
+### 前置要求
+
+详见 [README.md](../../README.md)。
+
+### 安装步骤
+
+1. 克隆仓库
+2. 安装依赖：`rush update`
+3. 构建项目：`rush build`
+4. 启动开发服务器：`npm start`
+5. 打开浏览器访问 `http://localhost:3000`

--- a/packages/coze-js/README.md
+++ b/packages/coze-js/README.md
@@ -5,6 +5,8 @@
 [![bundle size](https://img.shields.io/bundlephobia/min/%40coze%2Fapi)](https://bundlephobia.com/package/@coze/api)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+English | [简体中文](./README.zh-CN.md)
+
 Official Node.js and Browser SDK for [Coze](https://www.coze.com)（or [扣子](https://www.coze.cn)） API platform.
 
 ## Quick Start
@@ -131,14 +133,15 @@ npm run test
 ### Node.js
 ```bash
 cd examples/coze-js-node
-cp config.default.js config.js  # Edit config.js with your credentials
-npm start src/chat.ts
+rush build
+npx tsx ./src/chat.ts
 ```
 
 ### Browser
 ```bash
 cd examples/coze-js-web
-npm run start
+rush build
+npx tsx ./src/chat.ts
 ```
 
 ## Documentation

--- a/packages/coze-js/README.zh-CN.md
+++ b/packages/coze-js/README.zh-CN.md
@@ -1,0 +1,149 @@
+# Coze API SDK
+[![npm version](https://img.shields.io/npm/v/%40coze%2Fapi)](https://www.npmjs.com/package/@coze/api)
+[![npm downloads](https://img.shields.io/npm/dm/%40coze%2Fapi)](https://www.npmjs.com/package/@coze/api)
+[![bundle size](https://img.shields.io/bundlephobia/min/%40coze%2Fapi)](https://bundlephobia.com/package/@coze/api)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+[English](./README.md) | 简体中文
+
+[Coze](https://www.coze.com)（或[扣子](https://www.coze.cn)）API 平台的官方 Node.js 和浏览器 SDK。
+
+## 快速开始
+
+### 1. 安装
+
+```sh
+npm install @coze/api
+# 或
+pnpm install @coze/api
+```
+
+### 2. 基本用法
+
+```javascript
+import { CozeAPI, COZE_CN_BASE_URL, ChatStatus, RoleType } from '@coze/api';
+
+// 使用个人访问令牌初始化客户端
+const client = new CozeAPI({
+  token: 'your_pat_token', // 从 https://www.coze.cn/open/oauth/pats 获取你的 PAT
+  // 或者
+  // token: async () => {
+  //   // 如果令牌过期则刷新
+  //   return 'your_oauth_token';
+  // },
+  baseURL: COZE_CN_BASE_URL,
+});
+
+// 简单对话示例
+async function quickChat() {
+  const v = await client.chat.createAndPoll({
+    bot_id: 'your_bot_id',
+    additional_messages: [{
+      role: RoleType.User,
+      content: 'Hello!',
+      content_type: 'text',
+    }],
+  });
+
+  if (v.chat.status === ChatStatus.COMPLETED) {
+    for (const item of v.messages) {
+      console.log('[%s]:[%s]:%s', item.role, item.type, item.content);
+    }
+    console.log('usage', v.chat.usage);
+  }
+}
+```
+
+## 主要特性
+
+- 🌐 **完整 API 支持**：覆盖所有 [Coze 开放平台 API](https://www.coze.cn/docs/developer_guides/api_overview)
+- 🔐 **多种认证方式**：PAT、OAuth、JWT、OAuth PKCE
+- 🔄 **流式响应支持**：聊天和工作流的实时响应
+- 🌍 **跨平台**：支持 Node.js（≥14）和现代浏览器
+- ⚙️ **可配置**：超时、请求头、信号、调试选项
+
+## 认证选项
+
+1. **个人访问令牌（最简单）**
+```javascript
+const client = new CozeAPI({
+  token: 'your_pat_token',
+  baseURL: COZE_CN_BASE_URL,
+});
+```
+
+2. **其他认证方式**
+- OAuth Web 应用
+- OAuth PKCE
+- JWT
+- 设备码流程
+
+[查看认证示例 →](../../examples/coze-js-node/src/auth/)
+
+## 高级用法
+
+### 流式对话
+```javascript
+import { CozeAPI, ChatEventType, RoleType } from '@coze/api';
+
+async function streamChat() {
+  const stream = await client.chat.stream({
+    bot_id: 'your_bot_id',
+    additional_messages: [{
+      role: RoleType.User,
+      content: 'Hello!',
+      content_type: 'text',
+    }],
+  });
+
+  for await (const part of stream) {
+    if (part.event === ChatEventType.CONVERSATION_MESSAGE_DELTA) {
+      process.stdout.write(part.data.content); // 实时响应
+    }
+  }
+}
+```
+
+## 更多示例
+
+| 功能 | 描述 | 示例 |
+|---------|-------------|----------|
+| 对话 | 文本对话 | [chat.ts](../../examples/coze-js-node/src/chat.ts) |
+| Bot管理 | 创建和管理Bot | [bot.ts](../../examples/coze-js-node/src/bot.ts) |
+| 数据集 | 文档管理 | [datasets.ts](../../examples/coze-js-node/src/datasets.ts) |
+| 工作流 | 执行工作流 | [workflow.ts](../../examples/coze-js-node/src/workflow.ts) |
+| 语音 | 语音合成 | [voice.ts](../../examples/coze-js-node/src/voice.ts) |
+
+[查看所有示例 →](../../examples/coze-js-node/src/)
+
+## 开发
+
+```bash
+# 安装依赖
+rush update  # 如果未安装 `rush` 命令，请参见 ../../README.md
+
+# 运行测试
+npm run test
+```
+
+## 尝试示例
+
+### Node.js
+```bash
+cd examples/coze-js-node
+rush build
+npx tsx ./src/chat.ts
+```
+
+### 浏览器
+```bash
+cd examples/coze-js-web
+rush build
+npm run start
+```
+
+## 文档
+
+详细的 API 文档和指南，请访问：
+- [API 概览](https://www.coze.cn/docs/developer_guides/api_overview)
+- [认证指南](https://www.coze.cn/docs/developer_guides/authentication)

--- a/packages/coze-js/package.json
+++ b/packages/coze-js/package.json
@@ -40,7 +40,8 @@
   "files": [
     "dist",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "README.zh-CN.md"
   ],
   "scripts": {
     "build": "rm -rf dist && rslib build",

--- a/packages/coze-taro/README.zh-CN.md
+++ b/packages/coze-taro/README.zh-CN.md
@@ -1,34 +1,34 @@
 # Taro Coze API SDK
 
-English | [简体中文](./README.zh-CN.md)
-
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Official [Taro](https://docs.taro.zone/docs/) SDK for [Coze](https://www.coze.com)（or [扣子](https://www.coze.cn)） API platform.
+[English](./README.md) | 简体中文
 
-## Quick Start
+[Coze](https://www.coze.com)（或[扣子](https://www.coze.cn)）API 平台的官方 [Taro](https://docs.taro.zone/docs/) SDK。
 
-### 1. Installation
+## 快速开始
+
+### 1. 安装
 
 ```sh
 npm install @coze/taro-api @coze/api
-# or
+# 或
 pnpm install @coze/taro-api @coze/api
 ```
 
-### 2. Basic Usage
+### 2. 基本用法
 
 ```javascript
 import { COZE_COM_BASE_URL, RoleType, ChatStatus } from '@coze/api';
 import { CozeAPI } from '@coze/taro-api';
 
-// Initialize client with your Personal Access Token
+// 使用个人访问令牌初始化客户端
 const client = new CozeAPI({
-  token: 'your_pat_token', // Get your PAT from https://www.coze.com/open/oauth/pats
+  token: 'your_pat_token', // 从 https://www.coze.com/open/oauth/pats 获取你的 PAT
   baseURL: COZE_COM_BASE_URL,
 });
 
-// Simple chat example
+// 简单对话示例
 async function quickChat() {
   try {
     const v = await client.chat.createAndPoll({
@@ -49,20 +49,20 @@ async function quickChat() {
       console.log('usage', v.chat.usage);
     }
   } catch (error) {
-    console.error('Chat error:', error);
+    console.error('对话错误:', error);
     throw error;
   }
 }
 ```
 
-## Key Features
+## 主要特性
 
-- 🌐 **Consistent API**: Maintains consistent API with [Coze-JS](../coze-js/README.md)
-- 🔄 **Streaming Support**: Compatible with ByteDance Mini Program/WeChat Mini Program/H5
+- 🌐 **一致的 API**：与 [Coze-JS](../coze-js/README.md) 保持一致的 API
+- 🔄 **流式响应支持**：兼容字节小程序/微信小程序/H5
 
-## Advanced Usage
+## 高级用法
 
-### Streaming Chat
+### 流式对话
 
 ```javascript
 import { ChatEventType } from '@coze/api';
@@ -82,13 +82,13 @@ async function streamChat() {
 
   for await (const part of stream) {
     if (part.event === ChatEventType.CONVERSATION_MESSAGE_DELTA) {
-      console.log(part.data.content); // Real-time response
+      console.log(part.data.content); // 实时响应
     }
   }
 }
 ```
 
-### Refresh token
+### 刷新令牌
 
 ```javascript
 import { COZE_COM_BASE_URL } from '@coze/api';
@@ -103,7 +103,7 @@ const client = new CozeAPI({
 });
 ```
 
-### Abort streaming chat
+### 中断流式对话
 
 ```javascript
 import { ChatEventType } from '@coze/api';
@@ -130,37 +130,37 @@ async function streamChat() {
 
   for await (const part of stream) {
     if (part.event === ChatEventType.CONVERSATION_MESSAGE_DELTA) {
-      console.log(part.data.content); // Real-time response
+      console.log(part.data.content); // 实时响应
     }
   }
 }
 ```
 
-## Try Examples
+## 尝试示例
 
 ```bash
 cd examples/coze-js-taro
-cp .env.development .env.local # Edit .env.local with your credentials
+cp .env.development .env.local # 编辑 .env.local 填入你的凭证
 npm run dev:weapp
 ```
 
-## Notes
+## 注意事项
 ### Taro@3 + React
-The following configuration is required:
+需要以下配置：
 
 ```javascript
 export default defineConfig(() => {
   compiler: {
     type: 'webpack5',
     prebundle: {
-      // 1. Don‘t prebundle '@coze/taro-api'
+      // 1. 不要预打包 '@coze/taro-api'
       exclude: ['@coze/taro-api'],
     },
   },
 
   mini: {
     webpackChain(chain) {
-      // 2. Enable multi-platform support for '@coze/taro-api'
+      // 2. 为 '@coze/taro-api' 启用多平台支持
       chain.resolve.plugin('MultiPlatformPlugin').tap(args => {
         args[2]['include'] = ['@coze/taro-api'];
         return args;
@@ -170,7 +170,7 @@ export default defineConfig(() => {
 
   h5: {
     webpackChain(chain) {
-      // 2. Enable multi-platform support for '@coze/taro-api'
+      // 2. 为 '@coze/taro-api' 启用多平台支持
       chain.resolve.plugin('MultiPlatformPlugin').tap(args => {
         args[2]['include'] = ['@coze/taro-api'];
         return args;
@@ -180,9 +180,9 @@ export default defineConfig(() => {
 });
 ```
 
-## Documentation
+## 文档
 
-For detailed API documentation and guides, visit:
+详细的 API 文档和指南，请访问：
 
-- [API Overview](https://www.coze.com/docs/developer_guides/api_overview)
-- [Authentication Guide](https://www.coze.com/docs/developer_guides/authentication)
+- [API 概览](https://www.coze.com/docs/developer_guides/api_overview)
+- [认证指南](https://www.coze.com/docs/developer_guides/authentication)

--- a/packages/coze-taro/package.json
+++ b/packages/coze-taro/package.json
@@ -31,7 +31,8 @@
   "files": [
     "dist",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "README.zh-CN.md"
   ],
   "scripts": {
     "build": "rm -rf dist && tsc -b tsconfig.build.json -f",

--- a/packages/realtime-api/README.md
+++ b/packages/realtime-api/README.md
@@ -6,6 +6,8 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue.svg)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/coze-dev/coze-js/pulls)
 
+English | [简体中文](./README.zh-CN.md)
+
 A powerful real-time communication SDK for voice interactions with Coze AI bots.
 
 ## Features

--- a/packages/realtime-api/README.zh-CN.md
+++ b/packages/realtime-api/README.zh-CN.md
@@ -1,0 +1,104 @@
+# Coze 实时语音 API
+
+[![npm version](https://img.shields.io/npm/v/@coze/realtime-api.svg)](https://www.npmjs.com/package/@coze/realtime-api)
+[![npm downloads](https://img.shields.io/npm/dm/@coze/realtime-api.svg)](https://www.npmjs.com/package/@coze/realtime-api)
+[![license](https://img.shields.io/npm/l/@coze/realtime-api.svg)](https://github.com/coze-dev/coze-js/blob/main/LICENSE)
+[![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue.svg)](https://www.typescriptlang.org/)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/coze-dev/coze-js/pulls)
+
+[English](./README.md) | 简体中文
+
+一个强大的实时语音 SDK，用于与 Coze AI Bot 进行语音交互。
+
+## 特性
+1. 精准的语音识别：利用大语言模型进行 ASR（自动语音识别），我们的系统提供上下文理解能力。它可以参考之前提到的术语，理解说话风格和引用，并在噪音、专业术语和中英混合语音等挑战性场景下提供更高的识别准确率。
+
+2. 强大的 AI 代理能力：作为 AI 代理开发平台，Coze 提供全面的代理功能，包括：
+   - 记忆系统（文件存储、数据库、变量）
+   - 知识集成（文本、表格、图像）
+   - 技能（插件、触发器）
+   - 工作流编排（任务流、图像处理流程）
+
+3. 低延迟：使用 RTC（实时通信）技术实现，最大限度地减少通信管道中的延迟。
+
+4. 自然语音合成：使用由大语言模型驱动的高级 TTS（文本转语音）模型，我们的系统：
+   - 智能预测情感语境和语调
+   - 生成超自然、高保真、个性化的语音输出
+   - 在自然度、音质、韵律、呼吸模式和情感表达方面表现出色
+   - 无缝处理中英混合内容
+   - 提供类人的语气词和情感细微差别表达
+
+![api-overview](./assets/api-overview.png)
+
+## 安装
+
+```bash
+npm install @coze/realtime-api
+# 或
+yarn add @coze/realtime-api
+```
+
+## 快速开始
+
+```ts
+import { RealtimeClient, EventNames, RealtimeUtils } from "@coze/realtime-api";
+
+// 初始化客户端
+const client = new RealtimeClient({
+  baseURL: "https://api.coze.cn",
+  accessToken: "your_access_token",
+  // 或者
+  // accessToken: async () => {
+  //   // 如果令牌过期则刷新
+  //   return 'your_oauth_token';
+  // },
+  botId: "your_bot_id",
+  voiceId: "your_voice_id",           // 可选：指定音色 ID
+  conversationId: "conversation_id",   // 可选：用于对话连续性
+  debug: true,                        // 可选：启用调试日志
+  allowPersonalAccessTokenInBrowser: true,  // 可选：在浏览器中启用 PAT 令牌使用
+  audioMutedDefault: false,           // 可选：初始音频状态（默认：false）
+  suppressStationaryNoise: false,     // 可选：启用静态噪声抑制（默认：false）
+  suppressNonStationaryNoise: false,  // 可选：启用非静态噪声抑制（默认：false）
+});
+
+// 基本设置
+async function initializeVoiceChat() {
+  // 1. 验证设备权限
+  const result = await RealtimeUtils.checkDevicePermission();
+  if (!result.audio) {
+    throw new Error("需要麦克风访问权限");
+  }
+
+  // 2. 建立连接
+  await client.connect();
+}
+
+// 核心操作
+const operations = {
+  disconnect: () => client.disconnect(),
+  interrupt: () => client.interrupt(),
+  toggleMicrophone: (enabled: boolean) => client.setAudioEnable(enabled),
+  checkConnection: () => client.isConnected
+};
+
+// 事件处理
+function setupEventListeners() {
+  // 监听所有事件
+  client.on(EventNames.EventNames, console.log);
+
+  // 仅客户端事件
+  client.on(EventNames.ALL_CLIENT, console.log);
+
+  // 仅服务器端事件
+  client.on(EventNames.ALL_SERVER, console.log);
+
+  // 特定事件处理
+  client.on(EventNames.CONNECTED, (event) => {
+    console.log("连接已建立:", event);
+  });
+}
+```
+
+## 示例
+查看完整的示例，请参考我们的[实时语音控制台DEMO](../../examples/realtime-console)。

--- a/packages/realtime-api/package.json
+++ b/packages/realtime-api/package.json
@@ -36,7 +36,8 @@
   "files": [
     "dist",
     "LICENSE",
-    "README.md"
+    "README.md",
+    "README.zh-CN.md"
   ],
   "scripts": {
     "build": "rm -rf ./dist && rslib build",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added Simplified Chinese (zh-CN) README files for multiple packages:
		- `@coze/api`
		- `@coze/realtime-api`
		- `@coze/taro-api`
		- Node.js and Web examples
	- Updated main README with language selection option
	- Added links to official documentation
	- Enhanced examples section with new entries for Taro Mini Program demos

- **New Features**
	- Introduced new package `@coze/taro-api` for Taro Mini Program support
	- Clarified package descriptions for `@coze/api` and `@coze/realtime-api` by appending "SDK" to their titles
<!-- end of auto-generated comment: release notes by coderabbit.ai -->