### PR TITLE
feat(realtime-api): feat: add getRtcEngine method to expose RTC engine

### DIFF
--- a/common/changes/@coze/realtime-api/feat-realtime-api_2025-01-20-11-15.json
+++ b/common/changes/@coze/realtime-api/feat-realtime-api_2025-01-20-11-15.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/realtime-api",
+      "comment": "feat: add getRtcEngine method to expose RTC engine instance",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@coze/realtime-api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/common/changes/@coze/realtime-api/feat-realtime-api_2025-02-06-04-00.json
+++ b/common/changes/@coze/realtime-api/feat-realtime-api_2025-02-06-04-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/realtime-api",
+      "comment": "add test code",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@coze/realtime-api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/packages/realtime-api/README.md
+++ b/packages/realtime-api/README.md
@@ -83,7 +83,9 @@ const operations = {
   disconnect: () => client.disconnect(),
   interrupt: () => client.interrupt(),
   toggleMicrophone: (enabled: boolean) => client.setAudioEnable(enabled),
-  checkConnection: () => client.isConnected
+  checkConnection: () => client.isConnected,
+  // get rtc engine instance, for detail visit https://www.volcengine.com/docs/6348/104478#rtcengine
+  getRtcEngine: () => client.getRtcEngine(),
 };
 
 // Event Handling

--- a/packages/realtime-api/README.zh-CN.md
+++ b/packages/realtime-api/README.zh-CN.md
@@ -79,7 +79,9 @@ const operations = {
   disconnect: () => client.disconnect(),
   interrupt: () => client.interrupt(),
   toggleMicrophone: (enabled: boolean) => client.setAudioEnable(enabled),
-  checkConnection: () => client.isConnected
+  checkConnection: () => client.isConnected,
+  // 获取 RTC 引擎实例，详情请访问  https://www.volcengine.com/docs/6348/104478#rtcengine
+  getRtcEngine: () => client.getRtcEngine(),
 };
 
 // 事件处理

--- a/packages/realtime-api/package.json
+++ b/packages/realtime-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coze/realtime-api",
-  "version": "1.0.4-beta.1",
+  "version": "1.0.4-beta.2",
   "description": "A powerful real-time communication SDK for voice interactions with Coze AI bots | 扣子官方实时通信 SDK，用于与 Coze AI bots 进行语音交互",
   "keywords": [
     "coze",

--- a/packages/realtime-api/package.json
+++ b/packages/realtime-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coze/realtime-api",
-  "version": "1.0.4",
+  "version": "1.0.4-beta.1",
   "description": "A powerful real-time communication SDK for voice interactions with Coze AI bots | 扣子官方实时通信 SDK，用于与 Coze AI bots 进行语音交互",
   "keywords": [
     "coze",

--- a/packages/realtime-api/src/client.ts
+++ b/packages/realtime-api/src/client.ts
@@ -421,4 +421,8 @@ export class EngineClient extends RealtimeEventHandler {
       throw e;
     }
   }
+
+  getRtcEngine() {
+    return this.engine;
+  }
 }

--- a/packages/realtime-api/src/index.ts
+++ b/packages/realtime-api/src/index.ts
@@ -1,4 +1,8 @@
-import { type ScreenConfig, type AudioPropertiesConfig } from '@volcengine/rtc';
+import {
+  type ScreenConfig,
+  type AudioPropertiesConfig,
+  type IRTCEngine,
+} from '@volcengine/rtc';
 import { CozeAPI, type CreateRoomData, type GetToken } from '@coze/api';
 
 import * as RealtimeUtils from './utils';
@@ -308,6 +312,15 @@ class RealtimeClient extends RealtimeEventHandler {
   async setVideoInputDevice(deviceId: string) {
     await this._client?.setVideoInputDevice(deviceId);
     this.dispatch(EventNames.VIDEO_INPUT_DEVICE_CHANGED, { deviceId });
+  }
+
+  /**
+   * en: Get the RTC engine instance, for detail visit https://www.volcengine.com/docs/6348/104481
+   *
+   * zh: 获取 RTC 引擎实例，详情请访问 https://www.volcengine.com/docs/6348/104481
+   */
+  getRtcEngine(): IRTCEngine | undefined {
+    return this._client?.getRtcEngine();
   }
 }
 

--- a/packages/realtime-api/test/client.spec.ts
+++ b/packages/realtime-api/test/client.spec.ts
@@ -398,4 +398,11 @@ describe('EngineClient', () => {
       );
     });
   });
+
+  describe('getRtcEngine', () => {
+    it('should get rtc engine', () => {
+      const engine = client.getRtcEngine();
+      expect(engine).toBeDefined();
+    });
+  });
 });

--- a/packages/realtime-api/test/index.spec.ts
+++ b/packages/realtime-api/test/index.spec.ts
@@ -52,6 +52,7 @@ describe('RealtimeClient', () => {
       initAIAnsExtension: vi.fn(),
       changeAIAnsExtension: vi.fn(),
       sendMessage: vi.fn(),
+      getRtcEngine: vi.fn(),
       dispatch: vi.fn(),
     } as any;
     (EngineClient as vi.Mock).mockImplementation(() => mockEngineClient);
@@ -330,6 +331,14 @@ describe('RealtimeClient', () => {
       expect(mockEngineClient.sendMessage).toHaveBeenCalledWith({
         message: 'test',
       });
+    });
+  });
+
+  describe('getRtcEngine', () => {
+    it('should return rtc engine instance', async () => {
+      await client.connect();
+      client.getRtcEngine();
+      expect(mockEngineClient.getRtcEngine).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
…e instance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added `getRtcEngine()` method to the Realtime API package
	- Provides direct access to the RTC (Real-Time Communication) engine instance
	- Enhances functionality for developers working with real-time communication
- **Tests**
	- Introduced test suites for the `getRtcEngine` method in both `EngineClient` and `RealtimeClient` classes
	- Verified the functionality of the `getRtcEngine` method through new test cases
- **Chores**
	- Updated package version to `1.0.4-beta.2`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->