### PR TITLE
feat: add node-fetch for streaming support in older Node.js  versions

### DIFF
--- a/common/changes/@coze/api/fix-bug_2025-02-05-11-43.json
+++ b/common/changes/@coze/api/fix-bug_2025-02-05-11-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/api",
+      "comment": "add node-fetch for streaming support in older Node.js  versions",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@coze/api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/common/changes/@coze/api/fix-bug_2025-02-06-05-16.json
+++ b/common/changes/@coze/api/fix-bug_2025-02-06-05-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/api",
+      "comment": "add test code",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@coze/api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/common/changes/@coze/api/fix-bug_2025-02-06-06-14.json
+++ b/common/changes/@coze/api/fix-bug_2025-02-06-06-14.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/api",
+      "comment": "add test code",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@coze/api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -1300,6 +1300,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
+      node-fetch:
+        specifier: ^3.3.2
+        version: 3.3.2
     devDependencies:
       '@coze-infra/eslint-config':
         specifier: workspace:*
@@ -6820,6 +6823,10 @@ packages:
     resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
     engines: {node: '>=0.10'}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-urls@4.0.0:
     resolution: {integrity: sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==}
     engines: {node: '>=14'}
@@ -7862,6 +7869,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
     engines: {node: '>=8'}
@@ -8045,6 +8056,10 @@ packages:
   form-data@4.0.1:
     resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
     engines: {node: '>= 6'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -9885,6 +9900,10 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+
   node-emoji@1.11.0:
     resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
 
@@ -9896,6 +9915,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-forge@1.3.1:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
@@ -12920,6 +12943,10 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   web-vitals@2.1.4:
     resolution: {integrity: sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg==}
@@ -19949,6 +19976,8 @@ snapshots:
     dependencies:
       assert-plus: 1.0.0
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-urls@4.0.0:
     dependencies:
       abab: 2.0.6
@@ -21280,6 +21309,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.2
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   figures@3.2.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -21472,6 +21506,10 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
 
   forwarded@0.2.0: {}
 
@@ -23599,6 +23637,8 @@ snapshots:
   node-addon-api@7.1.1:
     optional: true
 
+  node-domexception@1.0.0: {}
+
   node-emoji@1.11.0:
     dependencies:
       lodash: 4.17.21
@@ -23606,6 +23646,12 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-forge@1.3.1: {}
 
@@ -27068,6 +27114,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-streams-polyfill@3.3.3: {}
 
   web-vitals@2.1.4: {}
 

--- a/packages/coze-js/package.json
+++ b/packages/coze-js/package.json
@@ -30,7 +30,8 @@
   "browser": {
     "crypto": false,
     "os": false,
-    "jsonwebtoken": false
+    "jsonwebtoken": false,
+    "node-fetch": false
   },
   "types": "src/index.ts",
   "files": [
@@ -48,7 +49,8 @@
     "test:cov": "vitest --coverage --run"
   },
   "dependencies": {
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "node-fetch": "^3.3.2"
   },
   "devDependencies": {
     "@coze-infra/eslint-config": "workspace:*",

--- a/packages/coze-js/src/fetcher.ts
+++ b/packages/coze-js/src/fetcher.ts
@@ -53,7 +53,7 @@ const handleError = (error: any) => {
 };
 
 // node-fetch is used for streaming requests
-const adapterFetch = async (options: any): Promise<any> => {
+export const adapterFetch = async (options: any): Promise<any> => {
   const response = await fetch(options.url, {
     body: options.data,
     ...options,

--- a/packages/coze-js/src/fetcher.ts
+++ b/packages/coze-js/src/fetcher.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import fetch from 'node-fetch';
 import axios, {
   type AxiosResponseHeaders,
   type AxiosRequestConfig,
@@ -8,6 +9,7 @@ import axios, {
   type AxiosStatic,
 } from 'axios';
 
+import { isBrowser } from './utils';
 import {
   APIError,
   TimeoutError,
@@ -50,6 +52,27 @@ const handleError = (error: any) => {
   }
 };
 
+// node-fetch is used for streaming requests
+const adapterFetch = async (options: any): Promise<any> => {
+  const response = await fetch(options.url, {
+    body: options.data,
+    ...options,
+  });
+  return {
+    data: response.body,
+    ...response,
+  };
+};
+
+const isSupportNativeFetch = () => {
+  if (isBrowser()) {
+    return true;
+  }
+  // native fetch is supported in node 18.0.0 or higher
+  const version = process.version.slice(1);
+  return compareVersions(version, '18.0.0') >= 0;
+};
+
 export async function fetchAPI<ResultType>(
   url: string,
   options: FetchAPIOptions = {},
@@ -69,7 +92,11 @@ export async function fetchAPI<ResultType>(
   const response: AxiosResponse = await (axiosInstance as AxiosInstance)({
     url,
     responseType: options.isStreaming ? 'stream' : 'json',
-    adapter: options.isStreaming ? 'fetch' : undefined,
+    adapter: options.isStreaming
+      ? isSupportNativeFetch()
+        ? 'fetch'
+        : adapterFetch
+      : undefined,
     ...options,
   }).catch(error => {
     throw handleError(error);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced streaming support for older Node.js versions by integrating the `node-fetch` library for dynamic HTTP request handling.
- **Chores**
  - Added test code to verify the functionality of the `fetchAPI` method with streaming requests, ensuring robust performance across different environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->