### PR TITLE
feat(api):  Add opus/g711a/g711u codec support for realtime weboscket chat

### DIFF
--- a/common/changes/@coze/api/feat-opus_2025-05-08-02-37.json
+++ b/common/changes/@coze/api/feat-opus_2025-05-08-02-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/api",
+      "comment": "chat websocket support opus coder",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@coze/api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/common/changes/@coze/api/feat-opus_2025-05-08-02-38.json
+++ b/common/changes/@coze/api/feat-opus_2025-05-08-02-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/api",
+      "comment": "chat websocket support opus coder",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@coze/api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/common/changes/@coze/api/feat-opus_2025-05-08-08-20.json
+++ b/common/changes/@coze/api/feat-opus_2025-05-08-08-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/api",
+      "comment": "chat websocket support g711a&g711u coder",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@coze/api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/common/changes/@coze/api/feat-opus_2025-05-08-08-58.json
+++ b/common/changes/@coze/api/feat-opus_2025-05-08-08-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/api",
+      "comment": "chat websocket support g711a&g711u coder",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@coze/api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/common/changes/@coze/api/feat-opus_2025-05-08-09-22.json
+++ b/common/changes/@coze/api/feat-opus_2025-05-08-09-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/api",
+      "comment": "Add unit test",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@coze/api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -2038,6 +2038,9 @@ importers:
       node-fetch:
         specifier: ^2.x
         version: 2.7.0
+      opus-encdec:
+        specifier: ^0.1.1
+        version: 0.1.1
       reconnecting-websocket:
         specifier: ^4.4.0
         version: 4.4.0
@@ -2087,6 +2090,9 @@ importers:
       axios:
         specifier: ^1.7.7
         version: 1.7.7(debug@4.3.7)
+      types-opus-recorder:
+        specifier: ^1.0.1
+        version: 1.0.1
       typescript:
         specifier: ^5.5.3
         version: 5.6.3
@@ -12778,6 +12784,9 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  opus-encdec@0.1.1:
+    resolution: {integrity: sha512-TDzyGqYqrwn5UEUNaLsfLGu8Ma+HRNrgLYj7Vx5wfTnafAA21G6Bnm/qTIa3orQi/yZPZYmkdpO/gez4nfA1Rw==}
+
   ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
@@ -15737,6 +15746,9 @@ packages:
 
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
+
+  types-opus-recorder@1.0.1:
+    resolution: {integrity: sha512-UALYgAkKZnlG44UBMT2gz2b9ZvefFSf6XhhM8I0U2vdXDbOWQyGoa+oRnEzrPrPEvr7YRqvE0RW03Pne9r4txw==}
 
   typescript-compare@0.0.2:
     resolution: {integrity: sha512-8ja4j7pMHkfLJQO2/8tut7ub+J3Lw2S3061eJLFQcvs3tsmJKp8KG5NtpLn7KcY2w08edF74BSVN7qJS0U6oHA==}
@@ -30782,6 +30794,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  opus-encdec@0.1.1: {}
+
   ora@5.4.1:
     dependencies:
       bl: 4.1.0
@@ -34377,6 +34391,8 @@ snapshots:
   typedarray-to-buffer@3.1.5:
     dependencies:
       is-typedarray: 1.0.0
+
+  types-opus-recorder@1.0.1: {}
 
   typescript-compare@0.0.2:
     dependencies:

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -2090,9 +2090,6 @@ importers:
       axios:
         specifier: ^1.7.7
         version: 1.7.7(debug@4.3.7)
-      types-opus-recorder:
-        specifier: ^1.0.1
-        version: 1.0.1
       typescript:
         specifier: ^5.5.3
         version: 5.6.3
@@ -15746,9 +15743,6 @@ packages:
 
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
-
-  types-opus-recorder@1.0.1:
-    resolution: {integrity: sha512-UALYgAkKZnlG44UBMT2gz2b9ZvefFSf6XhhM8I0U2vdXDbOWQyGoa+oRnEzrPrPEvr7YRqvE0RW03Pne9r4txw==}
 
   typescript-compare@0.0.2:
     resolution: {integrity: sha512-8ja4j7pMHkfLJQO2/8tut7ub+J3Lw2S3061eJLFQcvs3tsmJKp8KG5NtpLn7KcY2w08edF74BSVN7qJS0U6oHA==}
@@ -34391,8 +34385,6 @@ snapshots:
   typedarray-to-buffer@3.1.5:
     dependencies:
       is-typedarray: 1.0.0
-
-  types-opus-recorder@1.0.1: {}
 
   typescript-compare@0.0.2:
     dependencies:

--- a/examples/coze-js-web/config/webpack.config.js
+++ b/examples/coze-js-web/config/webpack.config.js
@@ -334,6 +334,8 @@ module.exports = function (webpackEnv) {
     },
     module: {
       strictExportPresence: true,
+      // fix: Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
+      unknownContextCritical: false,
       rules: [
         // Handle node_modules packages that contain sourcemaps
         shouldUseSourceMap && {

--- a/examples/realtime-websocket/src/pages/chat/index.tsx
+++ b/examples/realtime-websocket/src/pages/chat/index.tsx
@@ -9,7 +9,10 @@ import {
 } from '@coze/api/ws-tools';
 import SendMessage from './send-message';
 import ReceiveMessage from './receive-message';
-import { ConversationAudioTranscriptUpdateEvent } from '@coze/api';
+import {
+  CommonErrorEvent,
+  ConversationAudioTranscriptUpdateEvent,
+} from '@coze/api';
 import Operation from './operation';
 import { AudioConfig, AudioConfigRef } from '../../components/audio-config';
 import { ConsoleLog } from '../../components/console-log';
@@ -135,6 +138,18 @@ function Chat() {
         console.log('[chat] transcript update', event);
         setTranscript(
           (event as ConversationAudioTranscriptUpdateEvent).data.content,
+        );
+      },
+    );
+    clientRef.current?.on(
+      WsChatEventNames.SERVER_ERROR,
+      (_: string, event: unknown) => {
+        console.log('[chat] error', event);
+        message.error(
+          '发生错误：' +
+            (event as CommonErrorEvent)?.data?.msg +
+            ' logid: ' +
+            (event as CommonErrorEvent)?.detail.logid,
         );
       },
     );

--- a/packages/coze-js/package.json
+++ b/packages/coze-js/package.json
@@ -65,6 +65,7 @@
     "agora-rte-extension": "^1.2.4",
     "jsonwebtoken": "^9.0.2",
     "node-fetch": "^2.x",
+    "opus-encdec": "^0.1.1",
     "reconnecting-websocket": "^4.4.0",
     "uuid": "^10.0.0",
     "ws": "^8.11.0"

--- a/packages/coze-js/src/resources/websockets/types.ts
+++ b/packages/coze-js/src/resources/websockets/types.ts
@@ -193,8 +193,8 @@ export interface CommonErrorEvent extends BaseEventWithDetail {
 interface AudioConfig {
   /** Input audio format, supports pcm/wav/ogg */
   format?: 'pcm' | 'wav' | 'ogg';
-  /** Input audio codec, supports pcm/opus */
-  codec?: 'pcm' | 'opus';
+  /** Input audio codec, supports pcm/opus/g711a/g711u */
+  codec?: AudioCodec;
   /** Input audio sample rate, default 24000 */
   sample_rate?: number;
   /** Number of audio channels, default 1 (mono) */
@@ -202,6 +202,8 @@ interface AudioConfig {
   /** Audio bit depth, default 16 */
   bit_depth?: number;
 }
+
+export type AudioCodec = 'pcm' | 'opus' | 'g711a' | 'g711u';
 
 interface ChatConfig {
   /** Additional information, typically used for business-related fields */

--- a/packages/coze-js/src/ws-tools/chat/index.ts
+++ b/packages/coze-js/src/ws-tools/chat/index.ts
@@ -65,22 +65,6 @@ class WsChatClient extends BaseWsChatClient {
         // this.log('input_audio_buffer_append', performance.now() - startTime);
         // startTime = performance.now();
       },
-      opusAudioCallback: data => {
-        const { raw } = data;
-        const base64String = btoa(
-          Array.from(new Uint8Array(raw))
-            .map(byte => String.fromCharCode(byte))
-            .join(''),
-        );
-        // send audio to ws
-        this.ws?.send({
-          id: uuid(),
-          event_type: WebsocketsEventType.INPUT_AUDIO_BUFFER_APPEND,
-          data: {
-            delta: base64String,
-          },
-        });
-      },
       wavAudioCallback: (blob, name) => {
         const event = {
           event_type: 'audio.input.dump' as const,

--- a/packages/coze-js/src/ws-tools/chat/index.ts
+++ b/packages/coze-js/src/ws-tools/chat/index.ts
@@ -6,7 +6,11 @@ import {
   type AIDenoiserProcessorLevel,
   type AIDenoiserProcessorMode,
 } from '../index';
-import { type ChatUpdateEvent, WebsocketsEventType } from '../../index';
+import {
+  type AudioCodec,
+  type ChatUpdateEvent,
+  WebsocketsEventType,
+} from '../../index';
 import BaseWsChatClient from './base';
 import { getAudioDevices } from '../utils';
 export { WsChatEventNames };
@@ -14,6 +18,7 @@ export { WsChatEventNames };
 class WsChatClient extends BaseWsChatClient {
   public recorder: PcmRecorder;
   private isMuted = false;
+  private inputAudioCodec: AudioCodec = 'pcm';
 
   constructor(config: WsChatClientOptions) {
     super(config);
@@ -30,7 +35,7 @@ class WsChatClient extends BaseWsChatClient {
 
   private async startRecord() {
     // 1. start recorder
-    await this.recorder.start();
+    await this.recorder.start(this.inputAudioCodec);
 
     // init stream player
     await this.wavStreamPlayer.add16BitPCM(new ArrayBuffer(0), this.trackId);
@@ -59,6 +64,22 @@ class WsChatClient extends BaseWsChatClient {
 
         // this.log('input_audio_buffer_append', performance.now() - startTime);
         // startTime = performance.now();
+      },
+      opusAudioCallback: data => {
+        const { raw } = data;
+        const base64String = btoa(
+          Array.from(new Uint8Array(raw))
+            .map(byte => String.fromCharCode(byte))
+            .join(''),
+        );
+        // send audio to ws
+        this.ws?.send({
+          id: uuid(),
+          event_type: WebsocketsEventType.INPUT_AUDIO_BUFFER_APPEND,
+          data: {
+            delta: base64String,
+          },
+        });
       },
       wavAudioCallback: (blob, name) => {
         const event = {
@@ -91,9 +112,6 @@ class WsChatClient extends BaseWsChatClient {
     const ws = await this.init();
     this.ws = ws;
 
-    if (!this.isMuted) {
-      await this.startRecord();
-    }
     const sampleRate = await this.recorder?.getSampleRate();
 
     const event: ChatUpdateEvent = {
@@ -119,6 +137,12 @@ class WsChatClient extends BaseWsChatClient {
         ...chatUpdate?.data,
       },
     };
+
+    this.inputAudioCodec = event.data?.input_audio?.codec || 'pcm';
+
+    if (!this.isMuted) {
+      await this.startRecord();
+    }
 
     this.ws.send(event);
 

--- a/packages/coze-js/src/ws-tools/recorder/pcm-recorder.ts
+++ b/packages/coze-js/src/ws-tools/recorder/pcm-recorder.ts
@@ -52,7 +52,6 @@ class PcmRecorder {
   private wavAudioProcessor2: WavAudioProcessor | undefined;
   private processor: AIDenoiserProcessor | undefined;
   private pcmAudioCallback: ((data: { raw: ArrayBuffer }) => void) | undefined;
-  private opusAudioCallback: ((data: { raw: ArrayBuffer }) => void) | undefined;
   private wavAudioCallback: ((blob: Blob, name: string) => void) | undefined;
   private dumpAudioCallback: ((blob: Blob, name: string) => void) | undefined;
   private static aiDenoiserSupport = false;
@@ -129,13 +128,13 @@ class PcmRecorder {
     // 实时音频处理
     if (inputAudioCodec === 'opus') {
       this.audioProcessor = new OpusAudioProcessor(data => {
-        this.opusAudioCallback?.({ raw: data });
+        this.pcmAudioCallback?.({ raw: data });
       });
     } else {
       // pcm 音频处理
       this.audioProcessor = new PcmAudioProcessor(data => {
         this.pcmAudioCallback?.({ raw: data });
-      });
+      }, inputAudioCodec);
     }
 
     let audioProcessor: IAudioProcessor | undefined;
@@ -177,7 +176,6 @@ class PcmRecorder {
     pcmAudioCallback,
     wavAudioCallback,
     dumpAudioCallback,
-    opusAudioCallback,
   }: {
     pcmAudioCallback?: (data: { raw: ArrayBuffer }) => void;
     wavAudioCallback?: (blob: Blob, name: string) => void;
@@ -194,7 +192,6 @@ class PcmRecorder {
     this.pcmAudioCallback = pcmAudioCallback;
     this.wavAudioCallback = wavAudioCallback;
     this.dumpAudioCallback = dumpAudioCallback;
-    this.opusAudioCallback = opusAudioCallback;
     this.recording = true;
   }
 

--- a/packages/coze-js/src/ws-tools/recorder/pcm-recorder.ts
+++ b/packages/coze-js/src/ws-tools/recorder/pcm-recorder.ts
@@ -11,12 +11,15 @@ import {
 
 import WavAudioProcessor from './processor/wav-audio-processor';
 import PcmAudioProcessor from './processor/pcm-audio-processor';
+import OpusAudioProcessor from './processor/opus-audio-processor';
+import type BaseAudioProcessor from './processor/base-audio-processor';
 import { checkDenoiserSupport } from '../utils';
 import {
   type AIDenoisingConfig,
   type AudioCaptureConfig,
   type WavRecordConfig,
 } from '../types';
+import { type AudioCodec } from '../../index';
 
 export enum AIDenoiserProcessorMode {
   NSNG = 'NSNG',
@@ -45,10 +48,11 @@ class PcmRecorder {
   private recording = false;
   private static denoiser: AIDenoiserExtension | undefined;
   private wavAudioProcessor: WavAudioProcessor | undefined;
-  private pcmAudioProcessor: PcmAudioProcessor | undefined;
+  private audioProcessor: BaseAudioProcessor | undefined;
   private wavAudioProcessor2: WavAudioProcessor | undefined;
   private processor: AIDenoiserProcessor | undefined;
   private pcmAudioCallback: ((data: { raw: ArrayBuffer }) => void) | undefined;
+  private opusAudioCallback: ((data: { raw: ArrayBuffer }) => void) | undefined;
   private wavAudioCallback: ((blob: Blob, name: string) => void) | undefined;
   private dumpAudioCallback: ((blob: Blob, name: string) => void) | undefined;
   private static aiDenoiserSupport = false;
@@ -72,7 +76,7 @@ class PcmRecorder {
     }
   }
 
-  async start() {
+  async start(inputAudioCodec: AudioCodec = 'pcm') {
     const {
       deviceId,
       mediaStreamTrack,
@@ -99,7 +103,7 @@ class PcmRecorder {
         AGC: audioCaptureConfig?.autoGainControl ?? true, // 是否开启音频增益控制
         microphoneId: deviceId,
         encoderConfig: {
-          sampleRate: 44100,
+          sampleRate: this.getSampleRate(),
         },
       });
     }
@@ -122,10 +126,17 @@ class PcmRecorder {
       });
     }
 
-    // pcm 音频处理
-    this.pcmAudioProcessor = new PcmAudioProcessor(data => {
-      this.pcmAudioCallback?.({ raw: data });
-    });
+    // 实时音频处理
+    if (inputAudioCodec === 'opus') {
+      this.audioProcessor = new OpusAudioProcessor(data => {
+        this.opusAudioCallback?.({ raw: data });
+      });
+    } else {
+      // pcm 音频处理
+      this.audioProcessor = new PcmAudioProcessor(data => {
+        this.pcmAudioCallback?.({ raw: data });
+      });
+    }
 
     let audioProcessor: IAudioProcessor | undefined;
     if (this.isSupportAIDenoiser()) {
@@ -144,7 +155,7 @@ class PcmRecorder {
         audioProcessor = this.audioTrack.pipe(this.processor);
       }
 
-      audioProcessor = audioProcessor.pipe(this.pcmAudioProcessor);
+      audioProcessor = audioProcessor.pipe(this.audioProcessor);
 
       if (this.wavAudioProcessor2) {
         audioProcessor = audioProcessor.pipe(this.wavAudioProcessor2);
@@ -153,7 +164,7 @@ class PcmRecorder {
 
       this.handleProcessor();
     } else {
-      audioProcessor = this.audioTrack.pipe(this.pcmAudioProcessor);
+      audioProcessor = this.audioTrack.pipe(this.audioProcessor);
       if (this.wavAudioProcessor) {
         audioProcessor = audioProcessor.pipe(this.wavAudioProcessor);
       }
@@ -166,10 +177,12 @@ class PcmRecorder {
     pcmAudioCallback,
     wavAudioCallback,
     dumpAudioCallback,
+    opusAudioCallback,
   }: {
     pcmAudioCallback?: (data: { raw: ArrayBuffer }) => void;
     wavAudioCallback?: (blob: Blob, name: string) => void;
     dumpAudioCallback?: (blob: Blob, name: string) => void;
+    opusAudioCallback?: (data: { raw: ArrayBuffer }) => void;
   } = {}) {
     if (!this.audioTrack || !this.stream) {
       throw new Error('audioTrack is not initialized');
@@ -181,7 +194,7 @@ class PcmRecorder {
     this.pcmAudioCallback = pcmAudioCallback;
     this.wavAudioCallback = wavAudioCallback;
     this.dumpAudioCallback = dumpAudioCallback;
-
+    this.opusAudioCallback = opusAudioCallback;
     this.recording = true;
   }
 
@@ -233,7 +246,7 @@ class PcmRecorder {
       // 2. 暂停所有处理器的录制
       this.wavAudioProcessor?.stopRecording();
       this.wavAudioProcessor2?.stopRecording();
-      this.pcmAudioProcessor?.stopRecording();
+      this.audioProcessor?.stopRecording();
 
       // 3. 更新录制状态
       this.recording = false;
@@ -255,7 +268,7 @@ class PcmRecorder {
       // 2. 恢复所有处理器的录制
       this.wavAudioProcessor?.startRecording();
       this.wavAudioProcessor2?.startRecording();
-      this.pcmAudioProcessor?.startRecording();
+      this.audioProcessor?.startRecording();
 
       // 3. 更新录制状态
       this.recording = true;
@@ -272,7 +285,7 @@ class PcmRecorder {
     // 1. 销毁所有音频处理器
     this.wavAudioProcessor?.destroy();
     this.wavAudioProcessor2?.destroy();
-    this.pcmAudioProcessor?.destroy();
+    this.audioProcessor?.destroy();
 
     // 2. 关闭并清理音频轨道
     if (this.audioTrack) {
@@ -351,7 +364,7 @@ class PcmRecorder {
    * 获取音频采样率
    */
   getSampleRate() {
-    return 44100;
+    return 48000;
     // return this.audioTrack?.getMediaStreamTrack().getSettings().sampleRate;
   }
 

--- a/packages/coze-js/src/ws-tools/recorder/processor/base-audio-processor.ts
+++ b/packages/coze-js/src/ws-tools/recorder/processor/base-audio-processor.ts
@@ -1,0 +1,14 @@
+import { AudioProcessor } from 'agora-rte-extension';
+
+/**
+ * BaseAudioProcessor
+ */
+abstract class BaseAudioProcessor extends AudioProcessor {
+  abstract startRecording(): void;
+
+  abstract stopRecording(): void;
+
+  abstract destroy(): void;
+}
+
+export default BaseAudioProcessor;

--- a/packages/coze-js/src/ws-tools/recorder/processor/opus-audio-processor.ts
+++ b/packages/coze-js/src/ws-tools/recorder/processor/opus-audio-processor.ts
@@ -1,0 +1,104 @@
+// @ts-expect-error no types
+import { OggOpusEncoder } from 'opus-encdec/src/oggOpusEncoder.js';
+// @ts-expect-error no types
+import OpusEncoderLib from 'opus-encdec/dist/libopus-encoder.js';
+import { type IAudioProcessorContext } from 'agora-rte-extension';
+
+import { AudioProcessorSrc } from './pcm-worklet-processor';
+import BaseAudioProcessor from './base-audio-processor';
+
+/**
+ * OpusAudioProcessor
+ */
+class OpusAudioProcessor extends BaseAudioProcessor {
+  name: 'OpusAudioProcessor';
+  private chunkProcessor?: (data: ArrayBuffer) => void;
+  private workletNode?: AudioWorkletNode;
+  private encoder?: OggOpusEncoder;
+  private encoderReady = false;
+
+  constructor(chunkProcessor: (data: ArrayBuffer) => void) {
+    super();
+    this.name = 'OpusAudioProcessor';
+    this.chunkProcessor = chunkProcessor;
+  }
+
+  protected async onNode(node: AudioNode, context: IAudioProcessorContext) {
+    const audioContext = context.getAudioContext();
+    await audioContext.audioWorklet.addModule(AudioProcessorSrc);
+    this.workletNode = new AudioWorkletNode(audioContext, 'pcm-processor');
+    node.connect(this.workletNode);
+
+    // 初始化裸 Opus 编码器
+    const encoderConfig = {
+      encoderApplication: 2049, // Full Band Audio
+      encoderFrameSize: 20, // ms
+      encoderSampleRate: audioContext.sampleRate,
+      numberOfChannels: 1,
+      rawOpus: true,
+      originalSampleRate: audioContext.sampleRate,
+    };
+    this.encoder = new OggOpusEncoder(encoderConfig, OpusEncoderLib);
+    if (this.encoder.isReady === false && this.encoder.onready) {
+      await new Promise(resolve => {
+        this.encoder.onready = resolve;
+      });
+    }
+    this.encoderReady = true;
+
+    this.workletNode.port.onmessage = event => {
+      if (!this.encoderReady) {
+        return;
+      }
+      const float32 = event.data.audioData as Float32Array;
+
+      // Opus-encdec 直接支持 Float32Array
+      this.encoder.encode([float32]);
+      const packets = this.encoder.encodedData || [];
+      this.encoder.encodedData = [];
+
+      if (packets && packets.length) {
+        for (const packet of packets) {
+          this.chunkProcessor?.(packet.buffer);
+        }
+      }
+    };
+
+    this.startRecording();
+    this.output(node, context);
+  }
+
+  startRecording() {
+    this.workletNode?.port.postMessage({ type: 'start' });
+  }
+
+  stopRecording() {
+    this.workletNode?.port.postMessage({ type: 'stop' });
+  }
+
+  /**
+   * en: Destroy and cleanup resources
+   * zh: 销毁并清理资源
+   */
+  destroy() {
+    this.stopRecording();
+    if (this.workletNode?.port) {
+      this.workletNode.port.onmessage = null;
+    }
+    if (this.workletNode) {
+      this.workletNode.disconnect();
+      this.workletNode = undefined;
+    }
+    if (AudioProcessorSrc) {
+      URL.revokeObjectURL(AudioProcessorSrc);
+    }
+    this.chunkProcessor = undefined;
+    if (this.encoder) {
+      this.encoder.destroy();
+      this.encoder = undefined;
+    }
+    this.encoderReady = false;
+  }
+}
+
+export default OpusAudioProcessor;

--- a/packages/coze-js/src/ws-tools/recorder/processor/pcm-audio-processor.ts
+++ b/packages/coze-js/src/ws-tools/recorder/processor/pcm-audio-processor.ts
@@ -1,6 +1,12 @@
 import { type IAudioProcessorContext } from 'agora-rte-extension';
 
-import { floatTo16BitPCM } from '../../utils';
+import {
+  floatTo16BitPCM,
+  encodeG711U,
+  float32ToInt16Array,
+  downsampleTo8000,
+  encodeG711A,
+} from '../../utils';
 import { AudioProcessorSrc } from './pcm-worklet-processor';
 import BaseAudioProcessor from './base-audio-processor';
 
@@ -8,11 +14,16 @@ class PcmAudioProcessor extends BaseAudioProcessor {
   name: 'PcmAudioProcessor';
   private chunkProcessor?: (data: ArrayBuffer) => void;
   private workletNode?: AudioWorkletNode;
+  private encoding: 'pcm' | 'g711a' | 'g711u';
 
-  constructor(chunkProcessor: (data: ArrayBuffer) => void) {
+  constructor(
+    chunkProcessor: (data: ArrayBuffer) => void,
+    encoding: 'pcm' | 'g711a' | 'g711u' = 'pcm',
+  ) {
     super();
     this.name = 'PcmAudioProcessor';
     this.chunkProcessor = chunkProcessor;
+    this.encoding = encoding;
   }
 
   protected async onNode(node: AudioNode, context: IAudioProcessorContext) {
@@ -24,9 +35,26 @@ class PcmAudioProcessor extends BaseAudioProcessor {
     // workletNode.connect(node);
 
     this.workletNode.port.onmessage = event => {
-      this.chunkProcessor?.(
-        floatTo16BitPCM(event.data.audioData as Float32Array),
-      );
+      const float32 = event.data.audioData as Float32Array;
+      let buffer: ArrayBuffer;
+      switch (this.encoding) {
+        case 'g711a': {
+          const float32_8000 = downsampleTo8000(float32);
+          const pcm16_8000 = float32ToInt16Array(float32_8000);
+          buffer = encodeG711A(pcm16_8000).buffer;
+          break;
+        }
+        case 'g711u': {
+          const float32_8000 = downsampleTo8000(float32);
+          const pcm16_8000 = float32ToInt16Array(float32_8000);
+          buffer = encodeG711U(pcm16_8000).buffer;
+          break;
+        }
+        case 'pcm':
+        default:
+          buffer = floatTo16BitPCM(float32);
+      }
+      this.chunkProcessor?.(buffer);
     };
 
     this.startRecording();

--- a/packages/coze-js/src/ws-tools/recorder/processor/pcm-audio-processor.ts
+++ b/packages/coze-js/src/ws-tools/recorder/processor/pcm-audio-processor.ts
@@ -1,12 +1,10 @@
-import {
-  AudioProcessor,
-  type IAudioProcessorContext,
-} from 'agora-rte-extension';
+import { type IAudioProcessorContext } from 'agora-rte-extension';
 
-import { AudioProcessorSrc } from './pcm-worklet-processor';
 import { floatTo16BitPCM } from '../../utils';
+import { AudioProcessorSrc } from './pcm-worklet-processor';
+import BaseAudioProcessor from './base-audio-processor';
 
-class PcmAudioProcessor extends AudioProcessor {
+class PcmAudioProcessor extends BaseAudioProcessor {
   name: 'PcmAudioProcessor';
   private chunkProcessor?: (data: ArrayBuffer) => void;
   private workletNode?: AudioWorkletNode;

--- a/packages/coze-js/test/ws-tools/recorder/pcm-recorder.spec.ts
+++ b/packages/coze-js/test/ws-tools/recorder/pcm-recorder.spec.ts
@@ -1,7 +1,7 @@
 /// <reference types="vitest" />
 // @vitest-environment jsdom
 /* eslint-disable */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import PcmRecorder, {
   AIDenoiserProcessorMode,
   AIDenoiserProcessorLevel,
@@ -23,8 +23,14 @@ const mockDenoiser = {
 };
 
 // Mock global window object
+const mockURL = {
+  createObjectURL: vi.fn().mockReturnValue('blob:mock-url'),
+  revokeObjectURL: vi.fn(),
+};
+
 vi.stubGlobal('window', {
   __denoiser: mockDenoiser,
+  __denoiserSupported: true,
   MediaStream: vi.fn().mockImplementation(function (tracks) {
     return {
       getTracks: () => tracks || [{ stop: vi.fn() }],
@@ -34,11 +40,25 @@ vi.stubGlobal('window', {
     enabled: true,
     stop: vi.fn(),
   })),
-  URL: {
-    createObjectURL: vi.fn(),
-    revokeObjectURL: vi.fn(),
-  },
+  URL: mockURL,
 });
+
+vi.stubGlobal('URL', mockURL);
+vi.stubGlobal('AudioContext', vi.fn().mockImplementation(() => ({
+  createGain: vi.fn().mockReturnValue({
+    connect: vi.fn(),
+    gain: { value: 1 },
+  }),
+  createMediaStreamSource: vi.fn().mockReturnValue({
+    connect: vi.fn(),
+  }),
+  createScriptProcessor: vi.fn().mockReturnValue({
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    addEventListener: vi.fn(),
+  }),
+  destination: {},
+})));
 
 // Mock agora-rtc-sdk-ng/esm
 vi.mock('agora-rtc-sdk-ng/esm', () => ({
@@ -73,44 +93,68 @@ vi.mock('agora-extension-ai-denoiser', () => ({
   AIDenoiserProcessor: class {},
 }));
 
-// Mock PcmAudioProcessor
-vi.mock('../../../src/ws-tools/recorder/processor/pcm-audio-processor', () => ({
-  default: class MockPcmAudioProcessor {
-    private callback: (data: ArrayBuffer) => void;
+// Define mock processors - move all processor mocking to a dedicated module factory
+// This avoids hoisting issues
+vi.mock('../../../src/ws-tools/recorder/processor/pcm-audio-processor', () => {
+  return {
+    default: vi.fn().mockImplementation((callback) => ({
+      startRecording: vi.fn(),
+      stopRecording: vi.fn(),
+      destroy: vi.fn(),
+      pipe: vi.fn().mockReturnThis(),
+      _callback: callback
+    }))
+  }
+});
 
-    constructor(callback: (data: ArrayBuffer) => void) {
-      this.callback = callback;
-    }
-    startRecording = vi.fn();
-    stopRecording = vi.fn();
-    destroy = vi.fn();
-    pipe = vi.fn().mockReturnThis();
-  },
-}));
+// Mock OpusAudioProcessor
+vi.mock('../../../src/ws-tools/recorder/processor/opus-audio-processor', () => {
+  return {
+    default: vi.fn().mockImplementation((callback) => ({
+      startRecording: vi.fn(),
+      stopRecording: vi.fn(),
+      destroy: vi.fn(),
+      pipe: vi.fn().mockReturnThis(),
+      _callback: callback
+    }))
+  }
+});
 
 // Mock WavAudioProcessor
-vi.mock('../../../src/ws-tools/recorder/processor/wav-audio-processor', () => ({
-  default: class MockWavAudioProcessor {
-    private callback: (data: { wav: Blob }) => void;
+vi.mock('../../../src/ws-tools/recorder/processor/wav-audio-processor', () => {
+  return {
+    default: vi.fn().mockImplementation((callback) => ({
+      startRecording: vi.fn(),
+      stopRecording: vi.fn(),
+      destroy: vi.fn(),
+      pipe: vi.fn().mockReturnThis(),
+      _callback: callback
+    }))
+  }
+});
 
-    constructor(callback: (data: { wav: Blob }) => void) {
-      this.callback = callback;
-    }
-    startRecording = vi.fn();
-    stopRecording = vi.fn();
-    destroy = vi.fn();
-    pipe = vi.fn().mockReturnThis();
-  },
-}));
-
-// Mock agora-rte-extension
-vi.mock('agora-rte-extension', () => ({
-  IAudioProcessor: class {},
-}));
+// Mock worklet processor
+vi.mock('../../../src/ws-tools/recorder/processor/pcm-worklet-processor', () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      startRecording: vi.fn(),
+      stopRecording: vi.fn(),
+      destroy: vi.fn(),
+      pipe: vi.fn().mockReturnThis()
+    }))
+  }
+});
 
 // Mock utils
 vi.mock('../../../src/ws-tools/utils', () => ({
   checkDenoiserSupport: vi.fn().mockReturnValue(true),
+  isBrowserExtension: vi.fn().mockReturnValue(false),
+  floatTo16BitPCM: vi.fn(),
+  float32ToInt16Array: vi.fn(),
+  downsampleTo8000: vi.fn(),
+  isMobile: vi.fn(),
+  encodeG711A: vi.fn(),
+  encodeG711U: vi.fn(),
 }));
 
 // Mock types
@@ -119,6 +163,8 @@ vi.mock('../../../src/ws-tools/types', () => ({
   AudioCaptureConfig: {},
   WavRecordConfig: {},
 }));
+
+
 
 describe('PcmRecorder', () => {
   let recorder: PcmRecorder;
@@ -270,12 +316,111 @@ describe('PcmRecorder', () => {
     });
 
     it('should return correct sample rate', () => {
-      expect(recorder.getSampleRate()).toBe(44100);
+      // According to the implementation, the sample rate is fixed at 48000
+      expect(recorder.getSampleRate()).toBe(48000);
     });
 
     it('should handle dump request', async () => {
       await recorder.start();
       recorder.dump();
+      expect(mockDenoiser.createProcessor().dump).toHaveBeenCalled();
+    });
+    
+    it('should not dump when processor is not initialized', () => {
+      // Create a recorder with processor unavailable
+      const customRecorder = new PcmRecorder({
+        aiDenoisingConfig: { mode: undefined },
+      });
+      
+      // Set up a spy on the log method
+      const logSpy = vi.spyOn(customRecorder as any, 'log');
+      
+      customRecorder.dump();
+      expect(logSpy).toHaveBeenCalledWith('processor is not initialized');
+    });
+  });
+  
+  describe('Debug and Error Handling', () => {
+    it('should log messages when debug is enabled', async () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      
+      // Create recorder with debug enabled
+      const debugRecorder = new PcmRecorder({ debug: true });
+      
+      // Trigger log and warn methods with private access
+      (debugRecorder as any).log('test log');
+      (debugRecorder as any).warn('test warning');
+      
+      expect(logSpy).toHaveBeenCalledWith('test log');
+      expect(warnSpy).toHaveBeenCalledWith('test warning');
+    });
+    
+    it('should not log messages when debug is disabled', () => {
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      
+      // Create recorder with debug disabled
+      const debugRecorder = new PcmRecorder({ debug: false });
+      
+      // Trigger log and warn methods with private access
+      (debugRecorder as any).log('test log');
+      (debugRecorder as any).warn('test warning');
+      
+      expect(logSpy).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+    
+    it('should handle warn message when trying to pause while not recording', async () => {
+      const warnSpy = vi.spyOn(recorder as any, 'warn');
+      
+      // Recorder should not be recording at this point
+      recorder.pause();
+      
+      expect(warnSpy).toHaveBeenCalledWith('error: recorder is not recording');
+    });
+    
+    it('should handle warn message when trying to resume while already recording', async () => {
+      const warnSpy = vi.spyOn(recorder as any, 'warn');
+      
+      await recorder.start();
+      await recorder.record(); // Now recording
+      
+      recorder.resume(); // Try to resume while already recording
+      
+      expect(warnSpy).toHaveBeenCalledWith('recorder is recording');
+    });
+  });
+  
+  describe('isSupportAIDenoiser and checkProcessor', () => {
+    it('should check if AI denoiser is supported', () => {
+      // Create a recorder with AI mode enabled
+      const aiEnabledRecorder = new PcmRecorder({
+        aiDenoisingConfig: { mode: AIDenoiserProcessorMode.NSNG },
+      });
+      
+      // Access the private method using type assertion
+      const supportResult = (aiEnabledRecorder as any).isSupportAIDenoiser();
+      expect(supportResult).toBe(true);
+      
+      // Create a recorder with AI mode disabled
+      const aiDisabledRecorder = new PcmRecorder({
+        aiDenoisingConfig: { mode: undefined },
+      });
+      
+      // The method returns undefined if the mode is not set, so explicitly check for falsy
+      expect(Boolean((aiDisabledRecorder as any).isSupportAIDenoiser())).toBe(false);
+    });
+    
+    it('should check if processor is initialized', async () => {
+      // Test with a processor that is initialized
+      await recorder.start();
+      await recorder.record();
+      expect((recorder as any).checkProcessor()).toBe(true);
+      
+      // Test with a processor that is not initialized
+      const newRecorder = new PcmRecorder({});
+      expect((newRecorder as any).checkProcessor()).toBe(false);
     });
   });
 });

--- a/packages/coze-js/test/ws-tools/utils.spec.ts
+++ b/packages/coze-js/test/ws-tools/utils.spec.ts
@@ -6,8 +6,13 @@ import {
   checkDevicePermission,
   getAudioDevices,
   floatTo16BitPCM,
+  float32ToInt16Array,
+  downsampleTo8000,
   isMobile,
   checkDenoiserSupport,
+  isBrowserExtension,
+  encodeG711A,
+  encodeG711U,
 } from '../../src/ws-tools/utils';
 import AgoraRTC from 'agora-rtc-sdk-ng';
 
@@ -116,6 +121,49 @@ describe('WS Tools Utils', () => {
     });
   });
 
+  describe('float32ToInt16Array', () => {
+    it('should convert Float32Array to Int16Array', () => {
+      const input = new Float32Array([0, 0.5, -0.5, 1, -1]);
+      const result = float32ToInt16Array(input);
+
+      expect(result).toBeInstanceOf(Int16Array);
+      expect(result.length).toBe(input.length);
+      expect(result[0]).toBe(0); // Zero remains zero
+      
+      // Instead of checking exact values with toBeCloseTo, check the values are proportionally correct
+      // For positive values, check they're between 0 and 0x7fff (32767)
+      expect(result[1]).toBeGreaterThan(0);
+      expect(result[1]).toBeLessThanOrEqual(0x7fff);
+      
+      // For negative values, check they're between -0x8000 (-32768) and 0
+      expect(result[2]).toBeLessThan(0);
+      expect(result[2]).toBeGreaterThanOrEqual(-0x8000);
+      
+      // Check that max values map to extremes
+      expect(result[3]).toBe(0x7fff); // 1.0 maps to max positive
+      expect(result[4]).toBe(-0x8000); // -1.0 maps to max negative
+    });
+  });
+
+  describe('downsampleTo8000', () => {
+    it('should downsample 48000Hz to 8000Hz', () => {
+      // Create a test array with 48 elements to simulate 48000Hz sampling rate
+      const input = new Float32Array(48);
+      for (let i = 0; i < 48; i++) {
+        input[i] = i / 48;
+      }
+
+      const result = downsampleTo8000(input);
+
+      // Should be downsampled by a factor of 6 (48000/8000)
+      expect(result.length).toBe(8);
+      // Check that values are sampled at the correct intervals
+      expect(result[0]).toBe(input[0]); // First sample
+      expect(result[1]).toBe(input[6]); // Sample at index 6
+      expect(result[7]).toBe(input[42]); // Last sample at index 42
+    });
+  });
+
   describe('isMobile', () => {
     it('should detect mobile devices', () => {
       const mockUserAgents = {
@@ -158,6 +206,14 @@ describe('WS Tools Utils', () => {
       expect(AgoraRTC.registerExtensions).toHaveBeenCalled();
     });
 
+    it('should initialize denoiser with custom assets path when provided', () => {
+      const customPath = '/custom/assets/path';
+      const result = checkDenoiserSupport(customPath);
+      expect(result).toBe(true);
+      // We'd need to verify the AIDenoiserExtension was created with the correct path
+      // but that's challenging with our current mock setup
+    });
+
     it('should return false when denoiser is not supported', () => {
       // Mock AIDenoiserExtension to return incompatible denoiser
       vi.spyOn(mockDenoiser, 'checkCompatibility').mockReturnValue(false);
@@ -165,6 +221,77 @@ describe('WS Tools Utils', () => {
       const result = checkDenoiserSupport();
       expect(result).toBe(false);
       expect(AgoraRTC.registerExtensions).not.toHaveBeenCalled();
+    });
+
+    it('should use cached denoiser support value when available', () => {
+      // Set the support value before calling the function
+      window.__denoiserSupported = true;
+      const checkCompatibilitySpy = vi.spyOn(mockDenoiser, 'checkCompatibility');
+      
+      const result = checkDenoiserSupport();
+      
+      expect(result).toBe(true);
+      // Should not check compatibility again
+      expect(checkCompatibilitySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isBrowserExtension', () => {
+    // Save original chrome reference and ensure TypeScript is happy
+    const originalChrome = typeof window !== 'undefined' ? (window as any).chrome : undefined;
+    const originalGlobalChrome = typeof global !== 'undefined' ? (global as any).chrome : undefined;
+
+    afterEach(() => {
+      // Restore original chrome references
+      (window as any).chrome = originalChrome;
+      (global as any).chrome = originalGlobalChrome;
+    });
+
+    it('should return true for browser extensions', () => {
+      // Mock both window.chrome and global chrome
+      const mockChrome = {
+        runtime: {
+          id: 'test-extension-id'
+        }
+      };
+      (window as any).chrome = mockChrome;
+      // In jsdom, we need to set the global chrome object as well
+      (global as any).chrome = mockChrome;
+
+      expect(isBrowserExtension()).toBe(true);
+    });
+
+    it('should return false when not in a browser extension', () => {
+      (window as any).chrome = undefined;
+      expect(isBrowserExtension()).toBe(false);
+
+      (window as any).chrome = {};
+      expect(isBrowserExtension()).toBe(false);
+
+      (window as any).chrome = { runtime: {} };
+      expect(isBrowserExtension()).toBe(false);
+    });
+  });
+
+  describe('encodeG711A', () => {
+    it('should encode PCM to G.711 A-law', () => {
+      const pcmData = new Int16Array([-32768, -16384, 0, 16384, 32767]);
+      const result = encodeG711A(pcmData);
+
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.length).toBe(pcmData.length);
+      // Specific encoding values would require detailed testing of the algorithm
+    });
+  });
+
+  describe('encodeG711U', () => {
+    it('should encode PCM to G.711 μ-law', () => {
+      const pcmData = new Int16Array([-32768, -16384, 0, 16384, 32767]);
+      const result = encodeG711U(pcmData);
+
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.length).toBe(pcmData.length);
+      // Specific encoding values would require detailed testing of the algorithm
     });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Opus and G.711 (A-law and μ-law) audio codecs in chat via WebSocket, enabling more flexible audio handling.
  - Enhanced audio recording to dynamically select and process different codecs.
- **Bug Fixes**
  - Improved error handling in chat WebSocket, providing clearer error messages to users.
- **Chores**
  - Updated dependencies to include Opus codec support.
- **Documentation**
  - Updated changelogs to reflect new audio codec support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->