### PR TITLE
feat(audio): Add G.711a and G.711u codec support to WavStreamPlayer

### DIFF
--- a/common/changes/@coze/api/feat-opus_2025-05-23-07-16.json
+++ b/common/changes/@coze/api/feat-opus_2025-05-23-07-16.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/api",
+      "comment": "Add G.711a and G.711u codec support to WavStreamPlayer",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@coze/api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/common/changes/@coze/realtime-api/feat-opus_2025-05-23-07-35.json
+++ b/common/changes/@coze/realtime-api/feat-opus_2025-05-23-07-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/realtime-api",
+      "comment": "Add ROOM_INFO event to expose room connection details",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@coze/realtime-api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/packages/coze-js/src/resources/websockets/types.ts
+++ b/packages/coze-js/src/resources/websockets/types.ts
@@ -485,7 +485,7 @@ export interface AudioDumpEvent extends BaseEventWithDetail {
 
 interface OutputAudio {
   /** Output audio codec */
-  codec?: 'pcm' | 'opus';
+  codec?: 'pcm' | 'opus' | 'g711a' | 'g711u';
   pcm_config?: {
     sample_rate?: number;
   };

--- a/packages/coze-js/src/ws-tools/chat/index.ts
+++ b/packages/coze-js/src/ws-tools/chat/index.ts
@@ -1,5 +1,6 @@
 import { v4 as uuid } from 'uuid';
 
+import { type AudioFormat } from '../wavtools/lib/wav_stream_player';
 import { type WsChatClientOptions, WsChatEventNames } from '../types';
 import {
   PcmRecorder,
@@ -123,7 +124,12 @@ class WsChatClient extends BaseWsChatClient {
       },
     };
 
-    this.inputAudioCodec = event.data?.input_audio?.codec || 'pcm';
+    this.wavStreamPlayer.setSampleRate(
+      event.data?.output_audio?.pcm_config?.sample_rate || 24000,
+    );
+    this.wavStreamPlayer.setDefaultFormat(
+      (event.data?.output_audio?.codec as AudioFormat) || 'pcm',
+    );
 
     if (!this.isMuted) {
       await this.startRecord();

--- a/packages/coze-js/src/ws-tools/wavtools/lib/codecs/g711.ts
+++ b/packages/coze-js/src/ws-tools/wavtools/lib/codecs/g711.ts
@@ -1,0 +1,67 @@
+/**
+ * G.711 codec implementation for A-law and μ-law
+ */
+
+// A-law to linear PCM conversion table
+const ALAW_TO_LINEAR_TABLE = new Int16Array(256);
+// μ-law to linear PCM conversion table
+const ULAW_TO_LINEAR_TABLE = new Int16Array(256);
+
+// Initialize conversion tables
+(function initTables() {
+  // A-law to linear PCM conversion
+  for (let i = 0; i < 256; i++) {
+    const aval = i ^ 0x55;
+    let t = (aval & 0x0f) << 4;
+    let seg = (aval & 0x70) >> 4;
+    
+    if (seg) {
+      t = (t + 0x108) << (seg - 1);
+    } else {
+      t += 8;
+    }
+    
+    ALAW_TO_LINEAR_TABLE[i] = ((aval & 0x80) ? t : -t);
+  }
+  
+  // μ-law to linear PCM conversion
+  for (let i = 0; i < 256; i++) {
+    const uval = ~i;
+    let t = ((uval & 0x0f) << 3) + 0x84;
+    let seg = (uval & 0x70) >> 4;
+    
+    t <<= seg;
+    
+    ULAW_TO_LINEAR_TABLE[i] = ((uval & 0x80) ? (0x84 - t) : (t - 0x84));
+  }
+})();
+
+/**
+ * Converts G.711 A-law encoded data to PCM16 format
+ * @param {Uint8Array} alawData - A-law encoded data
+ * @returns {Int16Array} - PCM16 data
+ */
+export function decodeAlaw(alawData: Uint8Array): Int16Array {
+  const pcmData = new Int16Array(alawData.length);
+  
+  for (let i = 0; i < alawData.length; i++) {
+    pcmData[i] = ALAW_TO_LINEAR_TABLE[alawData[i]];
+  }
+  
+  return pcmData;
+}
+
+/**
+ * Converts G.711 μ-law encoded data to PCM16 format
+ * @param {Uint8Array} ulawData - μ-law encoded data
+ * @returns {Int16Array} - PCM16 data
+ */
+export function decodeUlaw(ulawData: Uint8Array): Int16Array {
+  const pcmData = new Int16Array(ulawData.length);
+  
+  for (let i = 0; i < ulawData.length; i++) {
+    pcmData[i] = ULAW_TO_LINEAR_TABLE[ulawData[i]];
+  }
+  
+  return pcmData;
+}

--- a/packages/coze-js/src/ws-tools/wavtools/lib/codecs/index.ts
+++ b/packages/coze-js/src/ws-tools/wavtools/lib/codecs/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Export all codecs
+ */
+export * from './g711';

--- a/packages/coze-js/test/ws-tools/chat.spec.ts
+++ b/packages/coze-js/test/ws-tools/chat.spec.ts
@@ -84,6 +84,8 @@ vi.mock('@ws-tools/wavtools', () => ({
     togglePlay: vi.fn(),
     isPlaying: vi.fn(),
     setMediaStream: vi.fn(),
+    setSampleRate: vi.fn(),
+    setDefaultFormat: vi.fn(),
   })),
 }));
 
@@ -121,7 +123,10 @@ describe('WebSocket Chat Tools', () => {
   describe('constructor', () => {
     it('should initialize with correct configuration', () => {
       expect(client.ws).toBeNull();
-      expect(WavStreamPlayer).toHaveBeenCalledWith({ sampleRate: 24000, enableLocalLookback: true });
+      expect(WavStreamPlayer).toHaveBeenCalledWith({
+        sampleRate: 24000,
+        enableLocalLookback: true,
+      });
       expect(PcmRecorder).toHaveBeenCalled();
     });
   });

--- a/packages/coze-js/test/ws-tools/speech.spec.ts
+++ b/packages/coze-js/test/ws-tools/speech.spec.ts
@@ -33,11 +33,14 @@ vi.mock('../../src/websocket-api', () => ({
 vi.mock('../../src/ws-tools/wavtools', () => ({
   WavStreamPlayer: vi.fn().mockImplementation(() => ({
     add16BitPCM: vi.fn(),
+    addG711a: vi.fn(),
+    addG711u: vi.fn(),
     interrupt: vi.fn(),
     resume: vi.fn(),
     pause: vi.fn(),
     togglePlay: vi.fn(),
     isPlaying: vi.fn(),
+    defaultFormat: 'pcm',
   })),
 }));
 
@@ -280,7 +283,27 @@ describe('WsSpeechClient', () => {
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation();
       const mockError = new Error('Processing failed');
       vi.mocked(WavStreamPlayer).mockImplementationOnce(() => ({
+        scriptSrc: '',
+        sampleRate: 24000,
+        context: null,
+        stream: null,
+        trackSampleOffsets: {},
+        interruptedTrackIds: {},
+        isPaused: false,
+        enableLocalLookback: false,
+        defaultFormat: 'pcm',
+        localLookback: undefined,
         add16BitPCM: vi.fn().mockRejectedValue(mockError),
+        addG711a: vi.fn(),
+        addG711u: vi.fn(),
+        interrupt: vi.fn(),
+        resume: vi.fn(),
+        pause: vi.fn(),
+        togglePlay: vi.fn(),
+        isPlaying: vi.fn(),
+        _start: vi.fn(),
+        getTrackSampleOffset: vi.fn(),
+        setMediaStream: vi.fn()
       }));
 
       const client = new WsSpeechClient(mockConfig);

--- a/packages/realtime-api/src/event-names.ts
+++ b/packages/realtime-api/src/event-names.ts
@@ -15,6 +15,11 @@ enum EventNames {
    */
   ALL_SERVER = 'server.*',
   /**
+   * en: Room info
+   * zh: 房间信息
+   */
+  ROOM_INFO = 'client.room.info',
+  /**
    * en: Client connected
    * zh: 客户端连接
    */

--- a/packages/realtime-api/src/index.ts
+++ b/packages/realtime-api/src/index.ts
@@ -169,6 +169,13 @@ class RealtimeClient extends RealtimeEventHandler {
       );
     }
 
+    this.dispatch(EventNames.ROOM_INFO, {
+      roomId: roomInfo.room_id,
+      uid: roomInfo.uid,
+      token: roomInfo.token,
+      appId: roomInfo.app_id,
+    });
+
     this._isTestEnv = TEST_APP_ID === roomInfo.app_id;
 
     // Step2 create engine


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for G.711 A-law and μ-law audio codecs, enabling playback of additional audio formats in the audio player.
  - Introduced flexible audio format management with new methods for handling G.711 audio data.
  - Added a new event to provide detailed room connection information.

- **Bug Fixes**
  - Improved handling of audio format and sample rate settings for more robust audio playback.

- **Tests**
  - Expanded test coverage to include new audio codecs and player features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->