### PR TITLE
feat(api): feat: add Opus codec support for WebSocket audio streaming

### DIFF
--- a/common/changes/@coze/api/feat-opus_2025-06-19-13-35.json
+++ b/common/changes/@coze/api/feat-opus_2025-06-19-13-35.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/api",
+      "comment": "feat: add Opus codec support for WebSocket audio streaming",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@coze/api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/common/changes/@coze/api/feat-opus_2025-06-20-06-30.json
+++ b/common/changes/@coze/api/feat-opus_2025-06-20-06-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@coze/api",
+      "comment": "Added  method to ensure the  and  local loopback are ready before processing audio",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@coze/api",
+  "email": "shenxiaojie.316@bytedance.com"
+}

--- a/examples/realtime-websocket/src/components/audio-config/index.tsx
+++ b/examples/realtime-websocket/src/components/audio-config/index.tsx
@@ -46,8 +46,9 @@ export const AudioConfig = forwardRef<
     AIDenoiserProcessorLevel.SOFT,
   );
   const isDenoiserSupported = WsToolsUtils.checkDenoiserSupport();
-  const [noiseSuppression, setNoiseSuppression] =
-    useState(!isDenoiserSupported);
+  const [noiseSuppression, setNoiseSuppression] = useState(
+    !isDenoiserSupported || WsToolsUtils.isMobile(),
+  );
   const [echoCancellation, setEchoCancellation] = useState(true);
   const [autoGainControl, setAutoGainControl] = useState(true);
   const [debug, setDebug] = useState(false);

--- a/packages/coze-js/src/resources/websockets/types.ts
+++ b/packages/coze-js/src/resources/websockets/types.ts
@@ -506,6 +506,8 @@ interface OutputAudio {
     sample_rate?: number;
   };
   opus_config?: {
+    /**输出 opus 的采样率，默认 24000。 */
+    sample_rate?: number;
     /**输出 opus 的码率，默认 48000。 */
     bitrate?: number;
     /**输出 opus 是否使用 CBR 编码，默认为 false。 */

--- a/packages/coze-js/src/ws-tools/chat/base.ts
+++ b/packages/coze-js/src/ws-tools/chat/base.ts
@@ -2,10 +2,11 @@ import { v4 as uuid } from 'uuid';
 
 import { type WavStreamPlayer } from '../wavtools';
 import SentenceSynchronizer from './sentence-synchronizer';
+import OpusDecoder from './opus-decoder';
 import {
-  type WsChatClientOptions,
   WsChatEventNames,
   type WsChatCallbackHandler,
+  type WsChatClientOptions,
   type WsChatEventData,
 } from '../types';
 import {
@@ -33,6 +34,8 @@ abstract class BaseWsChatClient {
   protected outputAudioSampleRate = 24000;
   // 音字同步器实例
   protected sentenceSynchronizer: SentenceSynchronizer;
+  // Opus decoder instance
+  protected opusDecoder?: OpusDecoder;
 
   constructor(config: WsChatClientOptions) {
     this.api = new CozeAPI({
@@ -205,6 +208,14 @@ abstract class BaseWsChatClient {
     });
   }
 
+  protected async initOpusDecoder() {
+    this.opusDecoder = new OpusDecoder({
+      inputSampleRate: this.outputAudioSampleRate,
+      outputSampleRate: this.outputAudioSampleRate,
+    });
+    await this.opusDecoder.waitForReady();
+  }
+
   protected closeWs() {
     if (this.ws?.readyState === 1) {
       this.ws?.close();
@@ -241,16 +252,27 @@ abstract class BaseWsChatClient {
       view[i] = decodedContent.charCodeAt(i);
     }
 
-    // 设置首个音频 Delta 时间
-    this.sentenceSynchronizer.setFirstAudioDeltaTime();
-
-    // 更新最后一个句子的音频时长
-    this.sentenceSynchronizer.updateLatestSentenceAudioDuration(
-      decodedContent.length,
-    );
-
     try {
-      await this.wavStreamPlayer?.add16BitPCM(arrayBuffer, this.trackId);
+      let int16Array;
+      if (this.opusDecoder) {
+        // Decode the Opus data to PCM audio
+        int16Array = this.opusDecoder.decode(view);
+        if (!int16Array) {
+          throw new Error('Failed to decode Opus data');
+        }
+      }
+
+      // 设置首个音频 Delta 时间
+      this.sentenceSynchronizer.setFirstAudioDeltaTime();
+      // 更新最后一个句子的音频时长
+      this.sentenceSynchronizer.updateLatestSentenceAudioDuration(
+        int16Array ? int16Array.length : decodedContent.length,
+      );
+
+      await this.wavStreamPlayer?.add16BitPCM(
+        int16Array || arrayBuffer,
+        this.trackId,
+      );
 
       this.audioDeltaList.shift();
       if (this.audioDeltaList.length > 0) {

--- a/packages/coze-js/src/ws-tools/chat/index.ts
+++ b/packages/coze-js/src/ws-tools/chat/index.ts
@@ -38,15 +38,6 @@ class WsChatClient extends BaseWsChatClient {
       sampleRate: 24000,
       enableLocalLoopback: isMobilePlayer,
       volume: config.playbackVolumeDefault ?? 1,
-      // firstFrameCallback: timestamp => {
-      //   // this.ws?.send({
-      //   //   id: uuid(),
-      //   //   event_type: 'client.event',
-      //   //   data: {
-      //   //     first_audio_timestamp: timestamp,
-      //   //   },
-      //   // } as any);
-      // },
     });
 
     this.recorder = new PcmRecorder({
@@ -179,16 +170,21 @@ class WsChatClient extends BaseWsChatClient {
     // 强制设置输入音频的采样率为系统默认的采样率
     setValueByPath(event, 'data.input_audio.sample_rate', sampleRate);
 
-    this.wavStreamPlayer?.setSampleRate(
-      event.data?.output_audio?.pcm_config?.sample_rate || 24000,
-    );
+    this.inputAudioCodec = event.data?.input_audio?.codec || 'pcm';
+    this.outputAudioCodec = event.data?.output_audio?.codec || 'pcm';
+    if (this.outputAudioCodec === 'opus') {
+      this.outputAudioSampleRate =
+        event.data?.output_audio?.opus_config?.sample_rate || 24000;
+      await this.initOpusDecoder();
+    } else {
+      this.outputAudioSampleRate =
+        event.data?.output_audio?.pcm_config?.sample_rate || 24000;
+    }
+
     this.wavStreamPlayer?.setDefaultFormat(
       (event.data?.output_audio?.codec as AudioFormat) || 'pcm',
     );
-    this.inputAudioCodec = event.data?.input_audio?.codec || 'pcm';
-    this.outputAudioCodec = event.data?.output_audio?.codec || 'pcm';
-    this.outputAudioSampleRate =
-      event.data?.output_audio?.pcm_config?.sample_rate || 24000;
+    this.wavStreamPlayer?.setSampleRate(this.outputAudioSampleRate);
 
     this.sentenceSynchronizer.setOutputAudioConfig(
       this.outputAudioSampleRate,
@@ -214,6 +210,7 @@ class WsChatClient extends BaseWsChatClient {
     });
     await this.recorder?.destroy();
     await this.wavStreamPlayer?.destroy();
+    await this.opusDecoder?.destroy();
     this.emit(WsChatEventNames.DISCONNECTED, undefined);
 
     await new Promise(resolve => setTimeout(resolve, 500));

--- a/packages/coze-js/src/ws-tools/chat/index.ts
+++ b/packages/coze-js/src/ws-tools/chat/index.ts
@@ -201,6 +201,7 @@ class WsChatClient extends BaseWsChatClient {
     }
 
     this.emit(WsChatEventNames.CONNECTED, event);
+    this.isConnected = true;
   }
 
   async disconnect() {
@@ -216,6 +217,7 @@ class WsChatClient extends BaseWsChatClient {
     await new Promise(resolve => setTimeout(resolve, 500));
     this.listeners.clear();
     this.closeWs();
+    this.isConnected = false;
   }
 
   /**

--- a/packages/coze-js/src/ws-tools/chat/opus-decoder.ts
+++ b/packages/coze-js/src/ws-tools/chat/opus-decoder.ts
@@ -1,0 +1,111 @@
+// @ts-expect-error no types
+import { OggOpusDecoder } from 'opus-encdec/src/oggOpusDecoder.js';
+// @ts-expect-error no types
+import OpusDecoderLib from 'opus-encdec/dist/libopus-decoder.js';
+
+export interface OpusDecoderConfig {
+  /**
+   * Input sample rate of the encoded Opus data
+   * @default 24000
+   */
+  inputSampleRate?: number;
+
+  /**
+   * Output sample rate for the decoded PCM data
+   * If different from input, resampling will be performed
+   * @default 24000
+   */
+  outputSampleRate?: number;
+}
+
+class OpusDecoder {
+  private decoder: OggOpusDecoder;
+  private decoderReady = false;
+  private config: OpusDecoderConfig;
+
+  constructor(config: OpusDecoderConfig) {
+    this.config = config;
+
+    this.decoder = new OggOpusDecoder(
+      {
+        rawOpus: true,
+        numberOfChannels: 1,
+        decoderSampleRate: this.config.inputSampleRate || 24000,
+        outputBufferSampleRate: this.config.outputSampleRate || 24000,
+      },
+      OpusDecoderLib,
+    );
+
+    // Initialize the decoder
+    if (this.decoder.isReady === false && this.decoder.onready) {
+      this.decoder.onready = () => {
+        this.decoderReady = true;
+      };
+    } else {
+      this.decoderReady = true;
+    }
+  }
+
+  /**
+   * Decode Opus data to PCM audio
+   * @param data Opus encoded data as Uint8Array
+   * @returns Decoded PCM audio as Int16Array or null if error
+   */
+  decode(inputBuffer: Uint8Array): Int16Array | null {
+    try {
+      let decodedBuffer: Float32Array | undefined;
+      this.decoder.decodeRaw(inputBuffer, (outputBuffer: Float32Array) => {
+        decodedBuffer = outputBuffer;
+      });
+      if (!decodedBuffer) {
+        return null;
+      }
+      // 转成 Int16Array
+      const decodedBufferInt16 = new Int16Array(decodedBuffer.length);
+      for (let i = 0; i < decodedBuffer.length; i++) {
+        decodedBufferInt16[i] = decodedBuffer[i] * 0x8000;
+      }
+      return decodedBufferInt16;
+    } catch (error) {
+      console.error('Error decoding Opus data:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Check if the decoder is ready
+   */
+  isReady(): boolean {
+    return this.decoderReady;
+  }
+
+  /**
+   * Wait for the decoder to be ready
+   * @returns Promise that resolves when decoder is ready
+   */
+  async waitForReady(): Promise<void> {
+    if (this.decoderReady) {
+      return Promise.resolve();
+    }
+
+    return new Promise<void>(resolve => {
+      const checkInterval = setInterval(() => {
+        if (this.decoderReady) {
+          clearInterval(checkInterval);
+          resolve();
+        }
+      }, 10);
+    });
+  }
+
+  /**
+   * Release resources used by the decoder
+   */
+  destroy(): void {
+    if (this.decoder) {
+      this.decoder.destroy();
+    }
+  }
+}
+
+export default OpusDecoder;

--- a/packages/coze-js/src/ws-tools/wavtools/lib/wav_stream_player.ts
+++ b/packages/coze-js/src/ws-tools/wavtools/lib/wav_stream_player.ts
@@ -123,7 +123,16 @@ export class WavStreamPlayer {
   isPlaying(): boolean {
     return Boolean(this.context && this.streamNode && !this.isPaused && this.context.state === 'running');
   }
-
+  /**
+   * 如果使用了本地回环，需要确保音频上下文已经准备好
+   * @returns {Promise<void>}
+   */
+  async checkForReady() {
+    if (this.localLoopback && !this.context) {
+      await this._start();
+      await this.localLoopback.checkForReady();
+    }
+  }
   /**
    * Starts audio streaming
    * @private
@@ -170,7 +179,7 @@ export class WavStreamPlayer {
    * @param {string} [trackId]
    * @param {AudioFormat} [format] - Audio format: 'pcm', 'g711a', or 'g711u'
    */
-  async add16BitPCM(arrayBuffer: ArrayBuffer | Int16Array | Uint8Array, trackId: string = 'default', format?: AudioFormat): Promise<Int16Array> {
+  async add16BitPCM(arrayBuffer: ArrayBuffer | Int16Array | Uint8Array, trackId: string = 'default', format?: AudioFormat) {
     if (typeof trackId !== 'string') {
       throw new Error(`trackId must be a string`);
     } else if (this.interruptedTrackIds[trackId]) {
@@ -272,18 +281,17 @@ export class WavStreamPlayer {
    * @param {string} [trackId]
    * @returns {Int16Array}
    */
-  async addG711a(arrayBuffer: ArrayBuffer | Uint8Array, trackId: string = 'default'): Promise<Int16Array> {
-    return this.add16BitPCM(arrayBuffer, trackId, 'g711a');
+  async addG711a(arrayBuffer: ArrayBuffer | Uint8Array, trackId: string = 'default') {
+    await this.add16BitPCM(arrayBuffer, trackId, 'g711a');
   }
 
   /**
    * Adds G.711 μ-law encoded audio data to the currently playing audio stream
    * @param {ArrayBuffer|Uint8Array} arrayBuffer - G.711 μ-law encoded data
    * @param {string} [trackId]
-   * @returns {Int16Array}
    */
-  async addG711u(arrayBuffer: ArrayBuffer | Uint8Array, trackId: string = 'default'): Promise<Int16Array> {
-    return this.add16BitPCM(arrayBuffer, trackId, 'g711u');
+  async addG711u(arrayBuffer: ArrayBuffer | Uint8Array, trackId: string = 'default') {
+    await this.add16BitPCM(arrayBuffer, trackId, 'g711u');
   }
 
   setSampleRate(sampleRate: number) {

--- a/packages/coze-js/src/ws-tools/wavtools/lib/wav_stream_player.ts
+++ b/packages/coze-js/src/ws-tools/wavtools/lib/wav_stream_player.ts
@@ -169,13 +169,11 @@ export class WavStreamPlayer {
    * @param {ArrayBuffer|Int16Array|Uint8Array} arrayBuffer
    * @param {string} [trackId]
    * @param {AudioFormat} [format] - Audio format: 'pcm', 'g711a', or 'g711u'
-   * @returns {Int16Array}
    */
   async add16BitPCM(arrayBuffer: ArrayBuffer | Int16Array | Uint8Array, trackId: string = 'default', format?: AudioFormat): Promise<Int16Array> {
     if (typeof trackId !== 'string') {
       throw new Error(`trackId must be a string`);
     } else if (this.interruptedTrackIds[trackId]) {
-      return new Int16Array();
     }
     if (!this.streamNode) {
       await this._start();
@@ -217,7 +215,6 @@ export class WavStreamPlayer {
       buffer,
       trackId
     }, [transferableBuffer]);
-    return buffer;
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Opus audio codec in WebSocket audio streaming, enabling improved audio quality and configuration options.
  - Users can now set the Opus audio sample rate for output, with a default of 24000 Hz.
  - Introduced readiness checks and automatic reconnection for local audio loopback to enhance connection stability.
- **Bug Fixes**
  - Enhanced resource cleanup for audio decoders during disconnect, improving stability.
- **Refactor**
  - Updated audio playback logic to support Opus decoding and proper handling of decoded audio data.
  - Improved audio context initialization and playback readiness checks for smoother audio streaming.
- **Other Improvements**
  - Noise suppression is now enabled by default on mobile devices for better audio clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->